### PR TITLE
Get `Option.getOpt` across the line

### DIFF
--- a/src/Option.purs
+++ b/src/Option.purs
@@ -1105,6 +1105,17 @@ getWithDefault default proxy option = case get proxy option of
   Data.Maybe.Just value -> value
   Data.Maybe.Nothing -> default
 
+-- | Gets a suboption of the given option, if it exists; otherwise,
+-- | returns an empty option.
+getOpt ::
+  forall label option option' proxy suboption.
+  IsSymbol label =>
+  Prim.Row.Cons label (Opt.Option suboption) option' option =>
+  proxy label ->
+  Opt.Option option ->
+  Opt.Option suboption
+getOpt = Opt.getWithDefault Opt.empty
+
 -- | Adds a new key with the given value to an option.
 -- | The key must not already exist in the option.
 -- | If the key might already exist in the option, `set` should be used instead.

--- a/src/Option.purs
+++ b/src/Option.purs
@@ -1109,12 +1109,12 @@ getWithDefault default proxy option = case get proxy option of
 -- | returns an empty option.
 getOpt ::
   forall label option option' proxy suboption.
-  IsSymbol label =>
-  Prim.Row.Cons label (Opt.Option suboption) option' option =>
+  Data.Symbol.IsSymbol label =>
+  Prim.Row.Cons label (Option suboption) option' option =>
   proxy label ->
-  Opt.Option option ->
-  Opt.Option suboption
-getOpt = Opt.getWithDefault Opt.empty
+  Option option ->
+  Option suboption
+getOpt = getWithDefault empty
 
 -- | Adds a new key with the given value to an option.
 -- | The key must not already exist in the option.


### PR DESCRIPTION
This fixes the compilation errors in #7 so CI will pass. There's no other changes in this branch.

cc @bbarker.