### PR TITLE
Record based insert and set

### DIFF
--- a/test/Test.Main.purs
+++ b/test/Test.Main.purs
@@ -33,3 +33,20 @@ spec = do
           anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
           anotherOption = Option.set (Proxy :: _ "bar") 31 someOption
         Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assert.shouldEqual` Data.Maybe.Just 31
+    Test.Spec.describe "set'" do
+      Test.Spec.it "sets a value when it doesn't exist" do
+        let
+          someOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          someOption = Option.empty
+
+          anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          anotherOption = Option.set' { bar: 31 } someOption
+        Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assert.shouldEqual` Data.Maybe.Just 31
+      Test.Spec.it "can change the type" do
+        let
+          someOption :: Option.Option ( foo :: Boolean, bar :: Boolean )
+          someOption = Option.empty
+
+          anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          anotherOption = Option.set' { bar: 31 } someOption
+        Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assert.shouldEqual` Data.Maybe.Just 31

--- a/test/Test.Main.purs
+++ b/test/Test.Main.purs
@@ -50,3 +50,19 @@ spec = do
           anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
           anotherOption = Option.set' { bar: 31 } someOption
         Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assert.shouldEqual` Data.Maybe.Just 31
+      Test.Spec.it "can use a `Data.Maybe.Maybe _`" do
+        let
+          someOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          someOption = Option.empty
+
+          anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          anotherOption = Option.set' { bar: Data.Maybe.Just 31 } someOption
+        Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assert.shouldEqual` Data.Maybe.Just 31
+      Test.Spec.it "`Data.Maybe.Nothing` keeps the previous value" do
+        let
+          someOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          someOption = Option.fromRecord { bar: 31 }
+
+          anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
+          anotherOption = Option.set' { bar: Data.Maybe.Nothing } someOption
+        Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assert.shouldEqual` Data.Maybe.Just 31


### PR DESCRIPTION
This is based off of discussion in the [adding setMay and maySetOptState comment](https://github.com/joneshf/purescript-option/pull/5#discussion_r386135026), the [Is it possible to have a mix of required and optional rows in Record? comment](https://github.com/joneshf/purescript-option/issues/12#issuecomment-621764002), and other discussions with different people. If we can provide record-based operations, it makes things considerably easier.

For instance, we can say things like:
```PureScript
Option.set'
    { identifier_opt: Just idOpt
    , identifier: idMay
    , date: dateMay
    , lastModified: xsdDateMay
    , _numRelIds: Just _numRelIds
    , relId_opts: relIdOpts
    , relatedIdentifiers: relIdsMay
    , _numSupProds: Just _numSupProds
    , supProd_opts: supProdOpts
    , supplementaryProducts: supProdsMay
    }
    someOption
```
Which is a heck of a lot easier to deal with than the alternatives.

cc @bbarker This removes the unreleased `maySetOptState`/`setMay`. It should be equivalent and hopefully easier to use. Lemme know if this makes something unusable for you.