### PR TITLE
More record based values

### DIFF
--- a/test/Test.Main.purs
+++ b/test/Test.Main.purs
@@ -24,6 +24,36 @@ reporters =
 spec :: Test.Spec.Spec Unit
 spec = do
   Test.Spec.describe "Option" do
+    Test.Spec.describe "alter" do
+      Test.Spec.it "does nothing if values are not set" do
+        let
+          someOption :: Option.Option ( foo :: Boolean, bar :: Int, qux :: String )
+          someOption = Option.empty
+
+          bar ::
+            Data.Maybe.Maybe Int ->
+            Data.Maybe.Maybe String
+          bar value' = case value' of
+            Data.Maybe.Just value -> if value > 0 then Data.Maybe.Just "positive" else Data.Maybe.Nothing
+            Data.Maybe.Nothing -> Data.Maybe.Nothing
+        Option.alter { bar } someOption `Test.Spec.Assert.shouldEqual` Option.fromRecord {}
+      Test.Spec.it "manipulates all fields it can" do
+        let
+          someOption :: Option.Option ( foo :: Boolean, bar :: Int, qux :: String )
+          someOption = Option.fromRecord { bar: 31, qux: "hi" }
+
+          bar ::
+            Data.Maybe.Maybe Int ->
+            Data.Maybe.Maybe String
+          bar value' = case value' of
+            Data.Maybe.Just value -> if value > 0 then Data.Maybe.Just "positive" else Data.Maybe.Nothing
+            Data.Maybe.Nothing -> Data.Maybe.Nothing
+
+          qux ::
+            Data.Maybe.Maybe String ->
+            Data.Maybe.Maybe String
+          qux _ = Data.Maybe.Nothing
+        Option.alter { bar, qux } someOption `Test.Spec.Assert.shouldEqual` Option.fromRecord { bar: "positive" }
     Test.Spec.describe "fromRecordWithRequired" do
       Test.Spec.it "requires correct fields" do
         let


### PR DESCRIPTION
Akin to what we did in #20, we now do for `Option.delete`, `Option.get`, and `Option.modify`: we add values that are easier to work with. We also export a record-based version of the internal `alter` value that we've never exposed up to now.

`Option.get'` is probably the most interesting one because the type class instances mean you can do something like:
```PureScript
someOption :: Option.Option ( foo :: Boolean, bar :: Int, qux :: String )
someOption = Option.empty

someRecord :: Record ( foo :: Boolean, bar :: String )
someRecord =
  Option.get'
    { foo: false
    , bar: \x -> case x of
        Data.Maybe.Just x -> if x > 0 then "positive" else "non-positive"
        Data.Maybe.Nothing -> "not set"
    }
    someOption
```

and `someRecord` will end up like:

```PureScript
{ foo: false
, bar: "not set"
}
```