### PR TITLE
Don't `CI` action on `pull_request` event

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-- pull_request
 - push
 
 jobs:


### PR DESCRIPTION
We don't need to run a second build.

We cargo-culted this from the documentation, but we don't really need to
do this. Since the repo is setup to require every commit be at least
ahead of the `master` branch, we don't gain much from running the build
on `pull_request`. We remove it since we don't need it.