### PR TITLE
Allow `Data.Maybe.Maybe _` values for `FromRecord _ _ _`

### DIFF
--- a/test/Test.Option.purs
+++ b/test/Test.Option.purs
@@ -15,6 +15,7 @@ spec :: Test.Spec.Spec Unit
 spec =
   Test.Spec.describe "Test.Option" do
     spec_alter
+    spec_fromRecord
     spec_fromRecordWithRequired
     spec_get'
     spec_modify'
@@ -53,6 +54,74 @@ spec_alter =
           Data.Maybe.Maybe String
         qux _ = Data.Maybe.Nothing
       Option.alter { bar, qux } someOption `Test.Spec.Assertions.shouldEqual` Option.fromRecord { bar: "positive" }
+
+spec_fromRecord :: Test.Spec.Spec Unit
+spec_fromRecord =
+  Test.Spec.describe "fromRecord" do
+    Test.Spec.it "only sets the given values" do
+      let
+        option ::
+          Option.Option
+            ( age :: Int
+            , name :: String
+            )
+        option =
+          Option.fromRecord
+            { name: "Pat"
+            }
+      Option.toRecord option `Test.Spec.Assertions.shouldEqual` { age: Data.Maybe.Nothing, name: Data.Maybe.Just "Pat" }
+    Test.Spec.it "allows `Data.Maybe.Just _`" do
+      let
+        option ::
+          Option.Option
+            ( age :: Int
+            , name :: String
+            )
+        option =
+          Option.fromRecord
+            { name: Data.Maybe.Just "Pat"
+            }
+      Option.toRecord option `Test.Spec.Assertions.shouldEqual` { age: Data.Maybe.Nothing, name: Data.Maybe.Just "Pat" }
+    Test.Spec.it "allows `Data.Maybe.Nothing`" do
+      let
+        option ::
+          Option.Option
+            ( age :: Int
+            , name :: String
+            )
+        option =
+          Option.fromRecord
+            { name: Data.Maybe.Nothing
+            }
+      Option.toRecord option `Test.Spec.Assertions.shouldEqual` { age: Data.Maybe.Nothing, name: Data.Maybe.Nothing }
+    Test.Spec.it "allows `Data.Maybe.Just _` and `Data.Maybe.Nothing`" do
+      let
+        option ::
+          Option.Option
+            ( age :: Int
+            , name :: String
+            )
+        option =
+          Option.fromRecord
+            { age: Data.Maybe.Just 31
+            , name: Data.Maybe.Nothing
+            }
+      Option.toRecord option `Test.Spec.Assertions.shouldEqual` { age: Data.Maybe.Just 31, name: Data.Maybe.Nothing }
+    Test.Spec.it "allows nested `Data.Maybe.Maybe _`s" do
+      let
+        option ::
+          Option.Option
+            ( active :: Data.Maybe.Maybe Boolean
+            , age :: Data.Maybe.Maybe (Data.Maybe.Maybe Int)
+            , name :: String
+            )
+        option =
+          Option.fromRecord
+            { active: Data.Maybe.Just (Data.Maybe.Just true)
+            , age: Data.Maybe.Just (Data.Maybe.Just (Data.Maybe.Just 31))
+            , name: Data.Maybe.Just "Pat"
+            }
+      Option.toRecord option `Test.Spec.Assertions.shouldEqual` { active: Data.Maybe.Just (Data.Maybe.Just true), age: Data.Maybe.Just (Data.Maybe.Just (Data.Maybe.Just 31)), name: Data.Maybe.Just "Pat" }
 
 spec_fromRecordWithRequired :: Test.Spec.Spec Unit
 spec_fromRecordWithRequired =


### PR DESCRIPTION
Much like we did in f1a1baff95d1ac16d9eff0e89507e1b9d0f82bb7, we add an instance for `Option.FromRecord _ _ _` that allows `Data.Maybe.Maybe _` values to be passed in instead of requiring the underlying value always.

As shown in the example tests and checks in the `Option` module, this allows any combination of things like:
```PureScript
Option.fromRecord {}
Option.fromRecord { age: 31 }
Option.fromRecord { age: Data.Maybe.Just 31 }
Option.fromRecord { age: Data.Maybe.Nothing }
```

As with #20, nested `Data.Maybe.Maybe _`s end having to be wrapped with another layer of `Data.Maybe.Just _`.