### PR TITLE
Remove deprecated `fromRecordWithRequired`

### DIFF
--- a/src/Option.purs
+++ b/src/Option.purs
@@ -29,7 +29,6 @@ module Option
   , Record
   , alter
   , fromRecord
-  , fromRecordWithRequired
   , delete
   , delete'
   , empty
@@ -139,7 +138,6 @@ import Foreign.Index as Foreign.Index
 import Foreign.Object as Foreign.Object
 import Prim.Row as Prim.Row
 import Prim.RowList as Prim.RowList
-import Prim.TypeError as Prim.TypeError
 import Record as Record
 import Record.Builder as Record.Builder
 import Simple.JSON as Simple.JSON
@@ -2373,83 +2371,6 @@ fromRecord ::
 fromRecord record' = optional record
   where
   record :: Record () optional
-  record = fromRecord' record'
-
--- | The given `Record record` must have no more fields than expected.
--- |
--- | E.g. The following definitions are valid.
--- | ```PureScript
--- | option1 ::
--- |   Record
--- |     ( optional :: Option.Option ( foo :: Boolean, bar :: Int )
--- |     , required :: Record ()
--- |     )
--- | option1 = Option.fromRecordWithRequired { foo: true, bar: 31 }
--- |
--- | option2 ::
--- |   Record
--- |     ( optional :: Option.Option ( foo :: Boolean, bar :: Int )
--- |     , required :: Record ()
--- |     )
--- | option2 = Option.fromRecordWithRequired {}
--- |
--- | option3 ::
--- |   Record
--- |     ( optional :: Option.Option ( bar :: Int )
--- |     , required :: Record ( foo :: Boolean )
--- |     )
--- | option3 = Option.fromRecordWithRequired { foo: true }
--- | ```
--- |
--- | However, the following definitions are not valid as the given records have more fields than the expected `Option _`.
--- | ```PureScript
--- | -- This will not work as it has the extra field `baz`
--- | option3 ::
--- |   Record
--- |     ( optional :: Option.Option ( foo :: Boolean, bar :: Int )
--- |     , required :: Record ()
--- |     )
--- | option3 = Option.fromRecordWithRequired { foo: true, bar: 31, baz: "hi" }
--- |
--- | -- This will not work as it has the extra field `qux`
--- | option4 ::
--- |   Record
--- |     ( optional :: Option.Option ( foo :: Boolean, bar :: Int )
--- |     , required :: Record ()
--- |     )
--- | option4 = Option.fromRecordWithRequired { qux: [] }
--- | ```
--- |
--- | And, this definition is not valid as the given record lacks the required fields.
--- | ```PureScript
--- | option5 ::
--- |   Record
--- |     ( optional :: Option.Option ( foo :: Boolean, bar :: Int )
--- |     , required :: Record ( baz :: String )
--- |     )
--- | option5 = Option.fromRecordWithRequired { foo: true, bar: 31 }
--- | ```
--- |
--- | This is an alias for `fromRecord'` so the documentation is a bit clearer.
-fromRecordWithRequired ::
-  forall optional record required.
-  FromRecord record required optional =>
-  Prim.TypeError.Warn
-    ( Prim.TypeError.Above
-        (Prim.TypeError.Text "`Option.fromRecordWithRequired` is deprecated and will be removed in v6.0.0.")
-        (Prim.TypeError.Text "Use `Option.recordFromRecord` instead.")
-    ) =>
-  Prim.Record record ->
-  Prim.Record
-    ( optional :: Option optional
-    , required :: Prim.Record required
-    )
-fromRecordWithRequired record' =
-  { optional: optional record
-  , required: required record
-  }
-  where
-  record :: Record required optional
   record = fromRecord' record'
 
 -- | Attempts to fetch the value at the given key from an option.


### PR DESCRIPTION
We've got `recordFromRecord` now to use instead.