### PR TITLE
Fix `set'` and `recordSet`

### DIFF
--- a/src/Option.purs
+++ b/src/Option.purs
@@ -1770,15 +1770,24 @@ else instance ordOptionCons ::
 -- | the type from the iterated `RowList` is used.
 class Partition (list :: Prim.RowList.RowList) (requiredInput :: Prim.RowList.RowList) (optionalInput :: Prim.RowList.RowList) (requiredOutput :: Prim.RowList.RowList) (optionalOutput :: Prim.RowList.RowList) | list optionalInput requiredInput -> optionalOutput requiredOutput
 
-instance partitionNilNilNil :: Partition Prim.RowList.Nil requiredInput optionalInput Prim.RowList.Nil Prim.RowList.Nil
-else instance partitionConsConsAny ::
+instance partitionNilAnyAnyNilNil ::
+  Partition Prim.RowList.Nil requiredInput optionalInput Prim.RowList.Nil Prim.RowList.Nil
+else instance partitionConsConsAnyConsAny ::
   ( Partition list requiredInput optionalInput requiredOutput optionalOutput
     ) =>
   Partition (Prim.RowList.Cons label requiredValue list) (Prim.RowList.Cons label value requiredInput) optionalInput (Prim.RowList.Cons label requiredValue requiredOutput) optionalOutput
-else instance partitionConsAnyCons ::
+else instance partitionConsAnyConsAnyCons ::
   ( Partition list requiredInput optionalInput requiredOutput optionalOutput
     ) =>
   Partition (Prim.RowList.Cons label optionalValue list) requiredInput (Prim.RowList.Cons label value optionalInput) requiredOutput (Prim.RowList.Cons label optionalValue optionalOutput)
+else instance partitionConsConsAnyAnyAny ::
+  ( Partition (Prim.RowList.Cons label value list) requiredInput optionalInput requiredOutput optionalOutput
+    ) =>
+  Partition (Prim.RowList.Cons label value list) (Prim.RowList.Cons requiredLabel requiredValue requiredInput) optionalInput requiredOutput optionalOutput
+else instance partitionConsAnyConsAnyAny ::
+  ( Partition (Prim.RowList.Cons label value list) requiredInput optionalInput requiredOutput optionalOutput
+    ) =>
+  Partition (Prim.RowList.Cons label value list) requiredInput (Prim.RowList.Cons optionalLabel optionalValue optionalInput) requiredOutput optionalOutput
 
 -- | A typeclass that iterates a `RowList` attempting to read a `Foreign` to an `Option _`.
 class ReadForeignOption (list :: Prim.RowList.RowList) (option :: # Type) | list -> option where

--- a/test/Test.Option.purs
+++ b/test/Test.Option.purs
@@ -227,6 +227,22 @@ spec_recordSet =
         anotherRecord :: Option.Record ( foo :: Boolean ) ( bar :: Int )
         anotherRecord = Option.recordSet { bar: 31 } someRecord
       Option.recordToRecord anotherRecord `Test.Spec.Assertions.shouldEqual` { bar: Data.Maybe.Just 31, foo: false }
+    Test.Spec.it "can set any required and optional values" do
+      let
+        someRecord :: Option.Record ( foo :: Boolean, bar :: Int, baz :: String ) ( qux :: Boolean, cor :: Int, gar :: String )
+        someRecord = Option.recordFromRecord { foo: false, bar: 31, baz: "hi" }
+
+        anotherRecord :: Option.Record ( foo :: Boolean, bar :: Int, baz :: String ) ( qux :: Boolean, cor :: Int, gar :: String )
+        anotherRecord = Option.recordSet { baz: "hello", qux: true } someRecord
+      Option.recordToRecord anotherRecord `Test.Spec.Assertions.shouldEqual` { bar: 31, baz: "hello", cor: Data.Maybe.Nothing, foo: false, gar: Data.Maybe.Nothing, qux: Data.Maybe.Just true }
+    Test.Spec.it "can set any required and optional values with any interleaving of names" do
+      let
+        someRecord :: Option.Record ( a :: Boolean, c :: Boolean, e :: Boolean ) ( b :: Boolean, d :: Boolean, f :: Boolean )
+        someRecord = Option.recordFromRecord { a: false, c: false, e: false }
+
+        anotherRecord :: Option.Record ( a :: Boolean, c :: Boolean, e :: Boolean ) ( b :: Boolean, d :: Boolean, f :: Boolean )
+        anotherRecord = Option.recordSet { b: true, c: true, d: true } someRecord
+      Option.recordToRecord anotherRecord `Test.Spec.Assertions.shouldEqual` { a: false, b: Data.Maybe.Just true, c: true, d: Data.Maybe.Just true, e: false, f: Data.Maybe.Nothing }
     Test.Spec.it "can change the type of both required and optional values" do
       let
         someRecord :: Option.Record ( foo :: Boolean ) ( bar :: Boolean )
@@ -278,6 +294,14 @@ spec_set' =
         anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
         anotherOption = Option.set' { bar: 31 } someOption
       Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assertions.shouldEqual` Data.Maybe.Just 31
+    Test.Spec.it "can work for any field" do
+      let
+        someOption :: Option.Option ( foo :: Boolean, bar :: Int, qux :: String )
+        someOption = Option.empty
+
+        anotherOption :: Option.Option ( foo :: Boolean, bar :: Int, qux :: String )
+        anotherOption = Option.set' { qux: "hi" } someOption
+      Option.get (Proxy :: _ "qux") anotherOption `Test.Spec.Assertions.shouldEqual` Data.Maybe.Just "hi"
     Test.Spec.it "can change the type" do
       let
         someOption :: Option.Option ( foo :: Boolean, bar :: Boolean )


### PR DESCRIPTION
Turns out that we hadn't validated enough cases for `Option.Partition _ _ _ _ _`. If you tried to set a field that wasn't part of the first set of fields alphabetically, there was no instance to get you there.

We're making a fix to the v5 series because 5.0.0 is effectively unusable without this. We'll merge it into the `master` branch after this.