### PR TITLE
Bump `actions/setup-node` to latest version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@53bed0742eb3f0455187c7c7042d27f51b856f02
     - name: Use Node.js 10.x
-      uses: actions/setup-node@dd2e8a486fdc1071872c594d5388fd6dce1a7534
+      uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
       with:
-        version: 10.x
+        node-version: 10.x
     - name: test
       run: make test


### PR DESCRIPTION
We want to try and address the failure in CI.

Turns out, there was a vulnerability that got patched and older versions
of `actions/setup-node` have broken because of it:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

We bump to the latest version (1.4.4) in an attempt to address it.