### PR TITLE
Fix behavior of `Option.set'`/`Option.recordSet`

### DIFF
--- a/src/Option.purs
+++ b/src/Option.purs
@@ -2086,9 +2086,7 @@ else instance setOptionConsMaybe ::
     Option option
   setOption _ record oldOption = case value' of
     Data.Maybe.Just value -> insert label value option
-    Data.Maybe.Nothing -> case get label oldOption of
-      Data.Maybe.Just value -> insert label value option
-      Data.Maybe.Nothing -> insertField label option
+    Data.Maybe.Nothing -> insertField label option
     where
     label :: Data.Symbol.SProxy label
     label = Data.Symbol.SProxy

--- a/test/Test.Option.purs
+++ b/test/Test.Option.purs
@@ -249,14 +249,14 @@ spec_recordSet =
         anotherRecord :: Option.Record ( foo :: Boolean ) ( bar :: Int )
         anotherRecord = Option.recordSet { bar: Data.Maybe.Just 31 } someRecord
       Option.recordToRecord anotherRecord `Test.Spec.Assertions.shouldEqual` { bar: Data.Maybe.Just 31, foo: false }
-    Test.Spec.it "`Data.Maybe.Nothing` keeps the previous value" do
+    Test.Spec.it "`Data.Maybe.Nothing` removes the previous value" do
       let
         someRecord :: Option.Record ( foo :: Boolean ) ( bar :: Int )
         someRecord = Option.recordFromRecord { bar: 31, foo: false }
 
         anotherRecord :: Option.Record ( foo :: Boolean ) ( bar :: Int )
         anotherRecord = Option.recordSet { bar: Data.Maybe.Nothing } someRecord
-      Option.recordToRecord anotherRecord `Test.Spec.Assertions.shouldEqual` { bar: Data.Maybe.Just 31, foo: false }
+      Option.recordToRecord anotherRecord `Test.Spec.Assertions.shouldEqual` { bar: Data.Maybe.Nothing, foo: false }
     Test.Spec.it "can set both required and optional values" do
       let
         someRecord :: Option.Record ( foo :: Boolean ) ( bar :: Int )
@@ -376,11 +376,11 @@ spec_set' =
         anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
         anotherOption = Option.set' { bar: Data.Maybe.Just 31 } someOption
       Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assertions.shouldEqual` Data.Maybe.Just 31
-    Test.Spec.it "`Data.Maybe.Nothing` keeps the previous value" do
+    Test.Spec.it "`Data.Maybe.Nothing` removes the previous value" do
       let
         someOption :: Option.Option ( foo :: Boolean, bar :: Int )
         someOption = Option.fromRecord { bar: 31 }
 
         anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
         anotherOption = Option.set' { bar: Data.Maybe.Nothing } someOption
-      Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assertions.shouldEqual` Data.Maybe.Just 31
+      Option.get (Proxy :: _ "bar") anotherOption `Test.Spec.Assertions.shouldEqual` Data.Maybe.Nothing


### PR DESCRIPTION
We want to remove values when they're `Data.Maybe.Nothing`.

The previous behavior is unintuitive and has caught people off guard.
Instead of keeping it, we make it more consistent with how other
record-based operations work: If the value is `Data.Maybe.Nothing`, we
remove the previous value (if it was set).

Hopefully, this is more intuitive to everyone.