### PR TITLE
Support null values when parsing optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ We can give that a spin with some different JSON values:
 
 > parse """{"name": "Pat", "title": "Dr."}"""
 (Right (Option.fromRecord { name: "Pat", title: "Dr." }))
+
+> parse """{ "name": null }"""
+Right (Option.fromRecord {})
+
+> parse """{ "title": null }"""
+Right (Option.fromRecord {})
+
+> parse """{ "name": null, "title": null }"""
+Right (Option.fromRecord {})
 ```
 
 We can also produce some different JSON values:
@@ -531,6 +540,15 @@ We can give that a spin with some different JSON values:
 
 > parse """{"name": "Pat", "title": "Dr."}"""
 (Right (Option.fromRecord { name: "Pat", title: "Dr." }))
+
+> parse """{ "name": null }"""
+Right (Option.fromRecord {})
+
+> parse """{ "title": null }"""
+Right (Option.fromRecord {})
+
+> parse """{ "name": null, "title": null }"""
+Right (Option.fromRecord {})
 ```
 
 We can also produce some different JSON values:
@@ -828,6 +846,15 @@ We can give that a spin with some different JSON values:
 
 > readJSON """{"name": "Pat", "title": "Dr."}"""
 (Right (Option.fromRecord { name: "Pat", title: "Dr." }))
+
+> readJSON """{ "name": null }"""
+Right (Option.fromRecord {})
+
+> readJSON """{ "title": null }"""
+Right (Option.fromRecord {})
+
+> readJSON """{ "name": null, "title": null }"""
+Right (Option.fromRecord {})
 ```
 
 We can also produce some different JSON values:
@@ -947,6 +974,9 @@ We can give that a spin with some different JSON values:
 
 > parse """{"name": "Pat", "title": "Dr."}"""
 (Right (Option.recordFromRecord { name: "Pat", title: "Dr." }))
+
+> parse """{ "name": "Pat", "title": null }"""
+Right (Option.recordFromRecord { name: "Pat" })
 ```
 
 We can also produce some different JSON values:
@@ -1162,6 +1192,9 @@ We can give that a spin with some different JSON values:
 
 > parse """{"name": "Pat", "title": "Dr."}"""
 (Right (Option.recordFromRecord { name: "Pat", title: "Dr." }))
+
+> parse """{ "name": "Pat", "title": null }"""
+Right (Option.recordFromRecord { name: "Pat" })
 ```
 
 Notice that we have to supply a `"name"` field in the JSON input otherwise it will not parse.
@@ -1474,6 +1507,9 @@ We can give that a spin with some different JSON values:
 
 > parse """{"name": "Pat", "title": "Dr."}"""
 (Right (Option.recordFromRecord { name: "Pat", title: "Dr." }))
+
+> parse """{ "name": "Pat", "title": null }"""
+Right (Option.recordFromRecord { name: "Pat" })
 ```
 
 We can also produce some different JSON values:

--- a/test/HowTo.DecodeAndEncodeJSONWithOptionalValuesInPureScriptArgonaut.purs
+++ b/test/HowTo.DecodeAndEncodeJSONWithOptionalValuesInPureScriptArgonaut.purs
@@ -79,3 +79,15 @@ spec_parse =
       Test.Spec.Assertions.shouldEqual
         (parse """{ "name": "Pat", "title": "Dr." }""")
         (Data.Either.Right (Option.fromRecord { name: "Pat", title: "Dr." }))
+    Test.Spec.it "doesn't fail a null name" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": null }""")
+        (Data.Either.Right (Option.fromRecord {}))
+    Test.Spec.it "doesn't fail for a null title" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "title": null }""")
+        (Data.Either.Right (Option.fromRecord {}))
+    Test.Spec.it "doesn't fail for a null name or title" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": null, "title": null }""")
+        (Data.Either.Right (Option.fromRecord {}))

--- a/test/HowTo.DecodeAndEncodeJSONWithOptionalValuesInPureScriptCodecArgonaut.purs
+++ b/test/HowTo.DecodeAndEncodeJSONWithOptionalValuesInPureScriptCodecArgonaut.purs
@@ -85,3 +85,15 @@ spec_parse =
       Test.Spec.Assertions.shouldEqual
         (parse """{ "name": "Pat", "title": "Dr." }""")
         (Data.Either.Right (Option.fromRecord { name: "Pat", title: "Dr." }))
+    Test.Spec.it "doesn't fail a null name" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": null }""")
+        (Data.Either.Right (Option.fromRecord {}))
+    Test.Spec.it "doesn't fail for a null title" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "title": null }""")
+        (Data.Either.Right (Option.fromRecord {}))
+    Test.Spec.it "doesn't fail for a null name or title" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": null, "title": null }""")
+        (Data.Either.Right (Option.fromRecord {}))

--- a/test/HowTo.DecodeAndEncodeJSONWithOptionalValuesInPureScriptSimpleJSON.purs
+++ b/test/HowTo.DecodeAndEncodeJSONWithOptionalValuesInPureScriptSimpleJSON.purs
@@ -58,6 +58,27 @@ spec_readJSON =
       Test.Spec.Assertions.shouldEqual
         (readJSON json)
         (Data.Either.Right (Option.fromRecord { name: "Pat", title: "Dr." }))
+    Test.Spec.it "doesn't fail a null name" do
+      let
+        json :: String
+        json = """{ "name": null }"""
+      Test.Spec.Assertions.shouldEqual
+        (readJSON json)
+        (Data.Either.Right (Option.fromRecord {}))
+    Test.Spec.it "doesn't fail for a null title" do
+      let
+        json :: String
+        json = """{ "title": null }"""
+      Test.Spec.Assertions.shouldEqual
+        (readJSON json)
+        (Data.Either.Right (Option.fromRecord {}))
+    Test.Spec.it "doesn't fail for a null name or title" do
+      let
+        json :: String
+        json = """{ "name": null, "title": null }"""
+      Test.Spec.Assertions.shouldEqual
+        (readJSON json)
+        (Data.Either.Right (Option.fromRecord {}))
 
 spec_writeJSON :: Test.Spec.Spec Unit
 spec_writeJSON =

--- a/test/HowTo.DecodeAndEncodeJSONWithRequiredAndOptionalValuesInPureScriptArgonaut.purs
+++ b/test/HowTo.DecodeAndEncodeJSONWithRequiredAndOptionalValuesInPureScriptArgonaut.purs
@@ -71,3 +71,7 @@ spec_parse =
       Test.Spec.Assertions.shouldEqual
         (parse """{ "name": "Pat", "title": "Dr." }""")
         (Data.Either.Right (Option.recordFromRecord { name: "Pat", title: "Dr." }))
+    Test.Spec.it "doesn't fail for null fields" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": "Pat", "title": null }""")
+        (Data.Either.Right (Option.recordFromRecord { name: "Pat" }))

--- a/test/HowTo.DecodeAndEncodeJSONWithRequiredAndOptionalValuesInPureScriptCodecArgonaut.purs
+++ b/test/HowTo.DecodeAndEncodeJSONWithRequiredAndOptionalValuesInPureScriptCodecArgonaut.purs
@@ -77,3 +77,7 @@ spec_parse =
       Test.Spec.Assertions.shouldEqual
         (parse """{ "name": "Pat", "title": "Dr." }""")
         (Data.Either.Right (Option.recordFromRecord { name: "Pat", title: "Dr." }))
+    Test.Spec.it "doesn't fail for null fields" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": "Pat", "title": null }""")
+        (Data.Either.Right (Option.recordFromRecord { name: "Pat" }))

--- a/test/HowTo.DecodeAndEncodeJSONWithRequiredAndOptionalValuesInPureScriptSimpleJSON.purs
+++ b/test/HowTo.DecodeAndEncodeJSONWithRequiredAndOptionalValuesInPureScriptSimpleJSON.purs
@@ -55,6 +55,10 @@ spec_parse =
       Test.Spec.Assertions.shouldEqual
         (parse """{ "name": "Pat", "title": "Dr." }""")
         (Data.Either.Right (Option.recordFromRecord { name: "Pat", title: "Dr." }))
+    Test.Spec.it "doesn't fail for null fields" do
+      Test.Spec.Assertions.shouldEqual
+        (parse """{ "name": "Pat", "title": null }""")
+        (Data.Either.Right (Option.recordFromRecord { name: "Pat" }))
 
 spec_writeJSON :: Test.Spec.Spec Unit
 spec_writeJSON =


### PR DESCRIPTION
We want to be more lenient in what we accept.

Up until now, we've required that the JSON we parse come in a specific
format: optional values don't exist. Unfortunately, things aren't so
consistent in the real world.

Instead of failing if we see an optional field that has a `null` value,
we parse it as though the value coming in was `Data.Maybe.Nothing`. This
is akin to how record-based values work (like `Option.set'`).

Since this changes the semantics of parsing, this is a breaking change,
and we should deal with it as such.

With this change, we ought to be able to be used in more places without
causing undue burden.