### PR TITLE
Update `Option.fromRecord` documentation

### DIFF
--- a/src/Option.purs
+++ b/src/Option.purs
@@ -2549,6 +2549,12 @@ empty = Option Foreign.Object.empty
 -- | option4 :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | option4 = Option.fromRecord { qux: [] }
 -- | ```
+-- |
+-- | You can also use `Option.fromRecord` to go from a `Record _` of `Maybe _` values to an `Option _`, e.g.:
+-- | ```PureScript
+-- | option5 :: Option.Option ( foo :: Boolean, bar :: Int )
+-- | option5 = Option.fromRecord { foo: Nothing, bar: Maybe 31 }
+-- | ```
 fromRecord ::
   forall optional record.
   FromRecord record () optional =>

--- a/src/Option.purs
+++ b/src/Option.purs
@@ -2550,7 +2550,9 @@ empty = Option Foreign.Object.empty
 -- | option4 = Option.fromRecord { qux: [] }
 -- | ```
 -- |
--- | You can also use `Option.fromRecord` to go from a `Record _` of `Maybe _` values to an `Option _`, e.g.:
+-- | You can also use `Option.fromRecord` to go from a `Record _` of `Maybe _` values to an `Option _`.
+-- |
+-- | E.g. The following definition is valid.
 -- | ```PureScript
 -- | option5 :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | option5 = Option.fromRecord { foo: Nothing, bar: Maybe 31 }


### PR DESCRIPTION
The fact that `Option.fromRecord` can take a `Record _` of `Maybe _` values as well was not documented. We update the documentation comment to mention this fact, for those who might be looking for this functionality.