### PR TITLE
Bump purescript to 0.15.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BOWER := npx bower
 BOWER_FLAGS ?=
 COMPILE_FLAGS ?=
 DEPENDENCIES := 'bower_components/purescript-*/src/**/*.purs'
+ESBUILD := npx esbuild
 NODE := node
 NPM := npm
 OUTPUT := output
@@ -37,12 +38,9 @@ $(OUTPUT):
 	mkdir -p $@
 
 $(OUTPUT)/test.js: $(SRC_OUTPUTS) $(TEST_OUTPUTS) | $(OUTPUT)
-	$(PURS) bundle \
-	  --main Test.Main \
-	  --module Test.Main \
-	  --output $@ \
-	  output/*/index.js \
-	  output/*/foreign.js
+	$(ESBUILD) $(OUTPUT)/Test.Main/index.js \
+	  --bundle \
+	  --outfile="$@"
 
 bower_components: bower.json node_modules
 	$(BOWER) $(BOWER_FLAGS) install

--- a/bower.json
+++ b/bower.json
@@ -16,29 +16,33 @@
     "url": "https://github.com/joneshf/purescript-option.git"
   },
   "dependencies": {
-    "purescript-argonaut-codecs": ">= 8.0.0 < 9.0.0",
-    "purescript-argonaut-core": ">= 6.0.0 < 7.0.0",
-    "purescript-codec": ">= 4.0.0 < 5.0.0",
-    "purescript-codec-argonaut": ">= 8.0.0 < 9.0.0",
-    "purescript-either": ">= 5.0.0 < 6.0.0",
-    "purescript-foreign": ">= 6.0.0 < 7.0.0",
-    "purescript-foreign-object": ">= 3.0.0 < 4.0.0",
-    "purescript-lists": ">= 6.0.0 < 7.0.0",
-    "purescript-maybe": ">= 5.0.0 < 6.0.0",
-    "purescript-profunctor": ">= 5.0.0 < 6.0.0",
-    "purescript-prelude": ">= 5.0.0 < 6.0.0",
-    "purescript-record": ">= 3.0.0 < 4.0.0",
-    "purescript-simple-json": ">= 8.0.0 < 9.0.0",
-    "purescript-transformers": ">= 5.0.0 < 6.0.0",
-    "purescript-tuples": ">= 6.0.0 < 7.0.0",
+    "purescript-argonaut-codecs": ">= 9.0.0 < 10.0.0",
+    "purescript-argonaut-core": ">= 7.0.0 < 8.0.0",
+    "purescript-codec": ">= 6.0.0 < 7.0.0",
+    "purescript-codec-argonaut": ">= 10.0.0 < 11.0.0",
+    "purescript-either": ">= 6.0.0 < 7.0.0",
+    "purescript-foreign": ">= 7.0.0 < 8.0.0",
+    "purescript-foreign-object": ">= 4.0.0 < 5.0.0",
+    "purescript-lists": ">= 7.0.0 < 8.0.0",
+    "purescript-maybe": ">= 6.0.0 < 7.0.0",
+    "purescript-profunctor": ">= 6.0.0 < 7.0.0",
+    "purescript-prelude": ">= 6.0.0 < 7.0.0",
+    "purescript-record": ">= 4.0.0 < 5.0.0",
+    "purescript-simple-json": ">= 9.0.0 < 10.0.0",
+    "purescript-transformers": ">= 6.0.0 < 7.0.0",
+    "purescript-tuples": ">= 7.0.0 < 8.0.0",
     "purescript-type-equality": ">= 4.0.0 < 5.0.0",
-    "purescript-unsafe-coerce": ">= 5.0.0 < 6.0.0"
+    "purescript-unsafe-coerce": ">= 6.0.0 < 7.0.0"
   },
   "devDependencies": {
-    "purescript-aff": ">= 6.0.0 < 7.0.0",
-    "purescript-datetime": ">= 5.0.0 < 6.0.0",
-    "purescript-foldable-traversable": ">= 5.0.0 < 6.0.0",
-    "purescript-psci-support": ">= 5.0.0 < 6.0.0",
-    "purescript-spec": ">= 5.0.0 < 6.0.0"
+    "purescript-aff": ">= 8.0.0 < 9.0.0",
+    "purescript-datetime": ">= 6.0.0 < 7.0.0",
+    "purescript-foldable-traversable": ">= 6.0.0 < 7.0.0",
+    "purescript-psci-support": ">= 6.0.0 < 7.0.0",
+    "purescript-spec": ">= 7.0.0 < 8.0.0"
+  },
+  "resolutions": {
+    "purescript-aff": ">= 8.0.0 < 9.0.0",
+    "purescript-parallel": "^7.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,142 +1,233 @@
 {
   "name": "purescript-option",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+  "packages": {
+    "": {
+      "name": "purescript-option",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "bower": "^1.8.14",
+        "purescript": "^0.15.15",
+        "purescript-psa": "^0.9.0",
+        "purty": "^7.0.0"
       }
     },
-    "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
-    "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true
+    "node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
-    "ansi-styles": {
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "aproba": {
+    "node_modules/aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
-    "arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-      "dev": true
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
+      "engines": {
+        "node": ">=8"
       }
     },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "bluebird": {
+    "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
-    "bower": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.12.tgz",
-      "integrity": "sha512-u1xy9SrwwoPlgjuHNjhV+YUPVdqyBj2ALBxuzeIUKXaPI2i2xypGgxqXkuHcITGdi5yBj5JuXgyMvgiWiS1S3Q==",
-      "dev": true
+    "node_modules/bower": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.14.tgz",
+      "integrity": "sha512-8Rq058FD91q9Nwthyhw0la9fzpBz0iwZTrt51LWl+w+PnJgZk9J+5wp3nibsJcIUPglMYXr4NRBaR+TUj0OkBQ==",
+      "dev": true,
+      "bin": {
+        "bower": "bin/bower"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
-    "byline": {
+    "node_modules/byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-      "dev": true
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "cacache": {
+    "node_modules/cacache": {
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
       "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
         "figgy-pudding": "^3.5.1",
@@ -153,86 +244,90 @@
         "y18n": "^4.0.0"
       }
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "chownr": {
+    "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
-      "requires": {
-        "restore-cursor": "^2.0.0"
+      "engines": {
+        "node": ">=6"
       }
     },
-    "color-convert": {
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-name": "1.1.3"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "concat-stream": {
+    "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
-      "requires": {
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
       }
     },
-    "copy-concurrently": {
+    "node_modules/copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
         "iferr": "^0.1.5",
@@ -241,110 +336,131 @@
         "run-queue": "^1.0.0"
       }
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cyclist": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.2.tgz",
+      "integrity": "sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "cyclist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
-      "dev": true
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "duplexify": {
+    "node_modules/duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "end-of-stream": {
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.4.0"
       }
     },
-    "env-paths": {
+    "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
     },
-    "escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "execa": {
+    "node_modules/execa": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
       "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
         "is-stream": "^2.0.0",
@@ -354,381 +470,703 @@
         "p-finally": "^2.0.0",
         "signal-exit": "^3.0.2",
         "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "figgy-pudding": {
+    "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+      "deprecated": "This module is no longer supported.",
       "dev": true
     },
-    "filesize": {
+    "node_modules/filesize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-4.2.1.tgz",
       "integrity": "sha512-bP82Hi8VRZX/TUBKfE24iiUGsB/sfm2WUrwTQyAzQrhO3V9IhcBBNBXMyzLY5orACxRyYJ3d2HeRVX+eFv4lmA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
-    "flush-write-stream": {
+    "node_modules/flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "from2": {
+    "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
     },
-    "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
-      "requires": {
-        "minipass": "^2.6.0"
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "fs-write-stream-atomic": {
+    "node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "integrity": "sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
         "imurmurhash": "^0.1.4",
         "readable-stream": "1 || 2"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "get-stream": {
+    "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "requires": {
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+      "engines": {
+        "node": ">=4"
       }
     },
-    "iferr": {
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/iferr": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "integrity": "sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA==",
       "dev": true
     },
-    "imurmurhash": {
+    "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
-    "is-plain-obj": {
+    "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
+      "engines": {
+        "node": ">=8"
       }
     },
-    "log-symbols": {
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "log-update": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.4.0.tgz",
-      "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
       "dev": true,
-      "requires": {
-        "ansi-escapes": "^3.2.0",
-        "cli-cursor": "^2.1.0",
-        "wrap-ansi": "^5.0.0"
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "yallist": "^3.0.2"
       }
     },
-    "merge-stream": {
+    "node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
-    "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.47.0"
-      }
-    },
-    "mimic-fn": {
+    "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
-      "requires": {
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.9.0"
-      }
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
-    "mississippi": {
+    "node_modules/mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "concat-stream": "^1.5.0",
         "duplexify": "^3.4.2",
         "end-of-stream": "^1.1.0",
@@ -739,23 +1177,30 @@
         "pumpify": "^1.3.3",
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "move-concurrently": {
+    "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "integrity": "sha512-hdrFxZOycD/g6A6SoI2bB5NA/5NEqD0569+S47WZhPvm46sD50ZHdYaFmnua5lndde9rCHGjmfK7Z8BuCt/PcQ==",
+      "deprecated": "This package is no longer supported.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
         "fs-write-stream-atomic": "^1.0.8",
@@ -764,153 +1209,185 @@
         "run-queue": "^1.0.3"
       }
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "npm-run-path": {
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "onetime": {
+    "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "p-finally": {
+    "node_modules/p-finally": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
       "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "parallel-transform": {
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parallel-transform": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
       "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-key": {
+    "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
-    "process-nextick-args": {
+    "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "promise-inflight": {
+    "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true
     },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
     },
-    "pumpify": {
+    "node_modules/pumpify": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
-      },
+      }
+    },
+    "node_modules/pumpify/node_modules/pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
       "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
-    "purescript": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.1.tgz",
-      "integrity": "sha512-dh87XeDP/JGe/3DKBMglkRuIRfGLGkL8beuLIl9KemzckgyuD+j7VK15eVb9n5Exp3DIr6SNEuGG4FjuQQ7Rpg==",
+    "node_modules/purescript": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.15.15.tgz",
+      "integrity": "sha512-4gwLNJa4KRiV+Wl+lyMY4MUFM6cSnIqvz7MvSTdLdvXJN2P9CrABnNbSspaokkNRFd9soWHBFDlYsAtRchqHtg==",
       "dev": true,
-      "requires": {
-        "purescript-installer": "^0.2.0"
+      "hasInstallScript": true,
+      "dependencies": {
+        "purescript-installer": "^0.3.5"
+      },
+      "bin": {
+        "purs": "purs.bin"
       }
     },
-    "purescript-installer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/purescript-installer/-/purescript-installer-0.2.5.tgz",
-      "integrity": "sha512-fQAWWP5a7scuchXecjpU4r4KEgSPuS6bBnaP01k9f71qqD28HaJ2m4PXHFkhkR4oATAxTPIGCtmTwtVoiBOHog==",
+    "node_modules/purescript-installer": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/purescript-installer/-/purescript-installer-0.3.5.tgz",
+      "integrity": "sha512-w04BBvW4BSQlspLsZ9Bs5vtUBZqvC4bC+FizC5GUp2/rpmYvXJ0CTf79Q3MKo2A8p1ZjqbhCI+SqdTQ30UZUIQ==",
       "dev": true,
-      "requires": {
-        "arch": "^2.1.1",
+      "dependencies": {
         "byline": "^5.0.0",
         "cacache": "^11.3.2",
         "chalk": "^2.4.2",
@@ -919,43 +1396,53 @@
         "filesize": "^4.1.2",
         "is-plain-obj": "^2.0.0",
         "log-symbols": "^3.0.0",
-        "log-update": "^3.2.0",
+        "log-update": "^4.0.0",
+        "make-fetch-happen": "^10.0.0",
         "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
         "ms": "^2.1.2",
         "once": "^1.4.0",
-        "pump": "^3.0.0",
-        "request": "^2.88.0",
         "rimraf": "^2.6.3",
-        "tar": "^4.4.6",
+        "semver": "^7.3.7",
+        "tar": "^6.1.11",
         "which": "^1.3.1",
         "zen-observable": "^0.8.14"
+      },
+      "bin": {
+        "install-purescript": "index.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "purescript-psa": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.8.2.tgz",
-      "integrity": "sha512-4Olf0aQQrNCfcDLXQI3gJgINEQ+3U+4QPLmQ2LHX2L/YOXSwM7fOGIUs/wMm/FQnwERUyQmHKQTJKB4LIjE2fg==",
-      "dev": true
+    "node_modules/purescript-psa": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/purescript-psa/-/purescript-psa-0.9.0.tgz",
+      "integrity": "sha512-yKsPiF4x/LjxOAzeUFIr/f0PtBgRK3IBwh4fNY6Ndz+p12QOEjReeJxqt5wIUo1O6RHPJLmb1Dro2xxc8I9w9w==",
+      "dev": true,
+      "bin": {
+        "psa": "index.js"
+      }
     },
-    "purty": {
+    "node_modules/purty": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/purty/-/purty-7.0.0.tgz",
       "integrity": "sha512-gHHghPEjRY39GUJ8KnOMRfPArJILGCXwEhX6BmEdNiLgZuCjLLBLyawGiKFjYMfy8H5Dsk5NbgwIGslrPrernA==",
-      "dev": true
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
-      "requires": {
+      "os": [
+        "linux",
+        "darwin",
+        "win32"
+      ],
+      "bin": {
+        "purty": "bin/purty.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
         "isarray": "~1.0.0",
@@ -965,349 +1452,469 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "^2.0.0",
+      "dependencies": {
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        }
+      "engines": {
+        "node": ">=8"
       }
     },
-    "rimraf": {
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "run-queue": {
+    "node_modules/run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "integrity": "sha512-ntymy489o0/QQplUDnpYAYUsO50K9SBrIVaKCWDOJzYJts0f9WH9RFJkyagebkw5+y1oi00R7ynNW/d12GBumg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "aproba": "^1.1.1"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "safer-buffer": {
+    "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
-    "shebang-command": {
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "shebang-regex": {
+    "node_modules/shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+      "engines": {
+        "node": ">=8"
       }
     },
-    "ssri": {
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
+    },
+    "node_modules/ssri": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
       "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
     },
-    "stream-each": {
+    "node_modules/stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
       }
     },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true
     },
-    "string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      }
-    },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "requires": {
-        "ansi-regex": "^4.1.0"
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "strip-final-newline": {
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "through2": {
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
-    },
-    "typedarray": {
+    "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
-    "unique-filename": {
+    "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "unique-slug": "^2.0.0"
       }
     },
-    "unique-slug": {
+    "node_modules/unique-slug": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "imurmurhash": "^0.1.4"
       }
     },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "which": {
+    "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "xtend": {
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     },
-    "y18n": {
+    "node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
-    "yallist": {
+    "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
-    "zen-observable": {
+    "node_modules/zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "author": "Hardy Jones <jones3.hardy@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "bower": "^1.8.8",
-    "purescript": "^0.14.0",
-    "purescript-psa": "^0.8.2",
+    "bower": "^1.8.14",
+    "purescript": "^0.15.15",
+    "purescript-psa": "^0.9.0",
     "purty": "^7.0.0"
   }
 }

--- a/src/Option.purs
+++ b/src/Option.purs
@@ -124,10 +124,8 @@ module Option
 
 import Prelude
 import Prim hiding (Record)
+
 import Control.Monad.Except as Control.Monad.Except
-import Control.Monad.Reader.Trans as Control.Monad.Reader.Trans
-import Control.Monad.Writer as Control.Monad.Writer
-import Control.Monad.Writer.Class as Control.Monad.Writer.Class
 import Data.Argonaut.Core as Data.Argonaut.Core
 import Data.Argonaut.Decode.Class as Data.Argonaut.Decode.Class
 import Data.Argonaut.Decode.Error as Data.Argonaut.Decode.Error
@@ -139,9 +137,8 @@ import Data.Either as Data.Either
 import Data.Identity as Data.Identity
 import Data.List as Data.List
 import Data.Maybe as Data.Maybe
-import Data.Profunctor.Star as Data.Profunctor.Star
+import Data.Profunctor as Data.Profunctor
 import Data.Show as Data.Show
-import Data.String as Data.String
 import Data.Symbol as Data.Symbol
 import Data.Tuple as Data.Tuple
 import Foreign as Foreign
@@ -152,7 +149,7 @@ import Prim.RowList as Prim.RowList
 import Record as Record
 import Record.Builder as Record.Builder
 import Simple.JSON as Simple.JSON
-import Type.Data.RowList as Type.Data.RowList
+import Type.Proxy as Type.Proxy
 import Unsafe.Coerce as Unsafe.Coerce
 
 -- | A collection of key/value pairs where any key and value may or may not exist.
@@ -160,8 +157,8 @@ import Unsafe.Coerce as Unsafe.Coerce
 newtype Option (row :: Row Type)
   = Option (Foreign.Object.Object (forall a. a))
 
--- A local proxy for `Prim.RowList.RowList` so as not to impose a hard requirement on `Type.Data.RowList.RLProxy` in the typeclasses we define.
--- `Type.Data.RowList.RLProxy` can still be used by callers, but it's not a requirement.
+-- A local proxy for `Prim.RowList.RowList` so as not to impose a hard requirement on `Type.Proxy.Proxy` in the typeclasses we define.
+-- `Type.Proxy.Proxy` can still be used by callers, but it's not a requirement.
 data Proxy (list :: Prim.RowList.RowList Type)
   = Proxy
 
@@ -360,14 +357,14 @@ instance encodeJsonRecordRequiredOptional ::
     optionalJSON :: Foreign.Object.Object Data.Argonaut.Core.Json
     optionalJSON = encodeJsonOption optionalProxy (optional record)
 
-    optionalProxy :: Type.Data.RowList.RLProxy optionalList
-    optionalProxy = Type.Data.RowList.RLProxy
+    optionalProxy :: Type.Proxy.Proxy optionalList
+    optionalProxy = Type.Proxy.Proxy
 
     requiredJSON :: Foreign.Object.Object Data.Argonaut.Core.Json
     requiredJSON = Data.Argonaut.Encode.Class.gEncodeJson (required record) requiredProxy
 
-    requiredProxy :: Type.Data.RowList.RLProxy requiredList
-    requiredProxy = Type.Data.RowList.RLProxy
+    requiredProxy :: Type.Proxy.Proxy requiredList
+    requiredProxy = Type.Proxy.Proxy
 
 -- | For required fields:
 -- |
@@ -418,14 +415,14 @@ instance showRecord ::
     where
     go :: String
     go = case requiredFields of
-      [] -> case optionalFields of
+      "" -> case optionalFields of
         Data.List.Cons x Data.List.Nil -> " " <> x <> " "
         Data.List.Cons x y -> " " <> go' x y <> " "
         Data.List.Nil -> ""
       fields -> case optionalFields of
-        Data.List.Cons x Data.List.Nil -> " " <> Data.String.joinWith ", " fields <> ", " <> x <> " "
-        Data.List.Cons x y -> " " <> Data.String.joinWith ", " fields <> ", " <> go' x y <> " "
-        Data.List.Nil -> " " <> Data.String.joinWith ", " fields <> " "
+        Data.List.Cons x Data.List.Nil -> " " <> fields <> ", " <> x <> " "
+        Data.List.Cons x y -> " " <> fields <> ", " <> go' x y <> " "
+        Data.List.Nil -> " " <> fields <> " "
 
     go' ::
       String ->
@@ -438,14 +435,14 @@ instance showRecord ::
     optionalFields :: Data.List.List String
     optionalFields = showOption optionalProxy (optional record')
 
-    optionalProxy :: Type.Data.RowList.RLProxy optionalList
-    optionalProxy = Type.Data.RowList.RLProxy
+    optionalProxy :: Type.Proxy.Proxy optionalList
+    optionalProxy = Type.Proxy.Proxy
 
-    requiredFields :: Array String
+    requiredFields :: String
     requiredFields = Data.Show.showRecordFields requiredProxy (required record')
 
-    requiredProxy :: Type.Data.RowList.RLProxy requiredList
-    requiredProxy = Type.Data.RowList.RLProxy
+    requiredProxy :: Type.Proxy.Proxy requiredList
+    requiredProxy = Type.Proxy.Proxy
 
 -- | For required fields:
 -- |
@@ -494,7 +491,7 @@ instance writeForeignRecordRequiredOptional ::
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.alter'' { bar: \_ -> Data.Maybe.Just 41 } someOption
@@ -555,8 +552,8 @@ else instance alterOptionCons ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -579,7 +576,7 @@ else instance alterOptionCons ::
 class DecodeJsonOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   decodeJsonOption ::
     forall proxy.
     proxy list ->
@@ -617,8 +614,8 @@ else instance decodeJsonOptionCons ::
       option <- option'
       Data.Either.Right (insertField label option)
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     key :: String
     key = Data.Symbol.reflectSymbol label
@@ -689,8 +686,8 @@ else instance deleteOptionCons ::
     Option option
   deleteOption _ record option' = deleteOption proxy record option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option :: Option oldOption'
     option = delete label option'
@@ -702,7 +699,7 @@ else instance deleteOptionCons ::
 class EncodeJsonOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   encodeJsonOption ::
     forall proxy.
     proxy list ->
@@ -743,8 +740,8 @@ else instance encodeJsonOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -756,7 +753,7 @@ else instance encodeJsonOptionCons ::
 class EqOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   eqOption ::
     forall proxy.
     proxy list ->
@@ -787,8 +784,8 @@ else instance eqOptionCons ::
     Boolean
   eqOption _ left right = leftValue == rightValue && rest
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     leftValue :: Data.Maybe.Maybe value
     leftValue = get label left
@@ -819,10 +816,10 @@ else instance eqOptionCons ::
 -- | Instead of having to say:
 -- | ```PureScript
 -- | Option.insert
--- |   (Data.Symbol.SProxy :: _ "foo")
+-- |   (Type.Proxy.Proxy :: _ "foo")
 -- |   true
 -- |   ( Option.insert
--- |       (Data.Symbol.SProxy :: _ "bar")
+-- |       (Type.Proxy.Proxy :: _ "bar")
 -- |       31
 -- |       Option.empty
 -- |   )
@@ -890,7 +887,7 @@ instance fromRecordAny ::
 class FromRecordOption (list :: Prim.RowList.RowList Type) (record :: Row Type) (option :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   fromRecordOption ::
     forall proxy.
     proxy list ->
@@ -921,8 +918,8 @@ else instance fromRecordOptionConsMaybe ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option :: Option option'
     option = fromRecordOption proxy record
@@ -947,8 +944,8 @@ else instance fromRecordOptionCons ::
     Option option
   fromRecordOption _ record = insert label value option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option :: Option option'
     option = fromRecordOption proxy record
@@ -963,7 +960,7 @@ else instance fromRecordOptionCons ::
 class FromRecordRequired (list :: Prim.RowList.RowList Type) (record :: Row Type) (required :: Row Type) | list -> required record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   fromRecordRequired ::
     forall proxy.
     proxy list ->
@@ -995,8 +992,8 @@ else instance fromRecordRequiredCons ::
     first :: Record.Builder.Builder (Prim.Record required') (Prim.Record required)
     first = Record.Builder.insert label value
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -1061,7 +1058,7 @@ instance getAny ::
 class GetOption (list :: Prim.RowList.RowList Type) (record' :: Row Type) (option :: Row Type) (record :: Row Type) | list -> record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   getOption ::
     forall proxy.
     proxy list ->
@@ -1083,8 +1080,8 @@ else instance getOptionConsFunction ::
   GetOption (Prim.RowList.Cons label (Data.Maybe.Maybe value -> result) list) givenRecord option record where
   getOption _ record' option = Record.insert label value record
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     optionValue :: Data.Maybe.Maybe value
     optionValue = get label option
@@ -1115,8 +1112,8 @@ else instance getOptionConsMaybe ::
     Data.Maybe.Just _ -> Record.insert label optionValue record
     Data.Maybe.Nothing -> Record.insert label recordValue record
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     optionValue :: Data.Maybe.Maybe value
     optionValue = get label option
@@ -1142,8 +1139,8 @@ else instance getOptionConsValue ::
     Data.Maybe.Just value -> Record.insert label value record
     Data.Maybe.Nothing -> Record.insert label recordValue record
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     optionValue :: Data.Maybe.Maybe value
     optionValue = get label option
@@ -1180,7 +1177,7 @@ class GetAll (option :: Row Type) (record :: Row Type) | option -> record where
   -- | E.g.
   -- | ```PureScript
   -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
-  -- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+  -- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
   -- |
   -- | -- This will be `Nothing` because the key `foo` does not exist in the option.
   -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
@@ -1188,7 +1185,7 @@ class GetAll (option :: Row Type) (record :: Row Type) | option -> record where
   -- |
   -- | -- This will be `Just { foo: true, bar: 31 }` because all keys exist in the option.
   -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
-  -- | bar = Option.getAll' (Option.insert (Data.Symbol.SProxy :: _ "foo") true someOption)
+  -- | bar = Option.getAll' (Option.insert (Type.Proxy.Proxy :: _ "foo") true someOption)
   -- | ```
   getAll' ::
     Option option ->
@@ -1210,7 +1207,7 @@ instance getAllAny ::
 class GetAllOption (list :: Prim.RowList.RowList Type) (option :: Row Type) (record :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   getAllOption ::
     forall proxy.
     proxy list ->
@@ -1234,8 +1231,8 @@ else instance getAllOptionCons ::
       Data.Maybe.Nothing -> Data.Maybe.Nothing
     Data.Maybe.Nothing -> Data.Maybe.Nothing
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -1314,8 +1311,8 @@ else instance insertOptionConsMaybe ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option :: Option option'
     option = insertOption proxy record oldOption
@@ -1341,8 +1338,8 @@ else instance insertOptionConsValue ::
     Option option
   insertOption _ record oldOption = insert label value option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option :: Option option'
     option = insertOption proxy record oldOption
@@ -1420,10 +1417,7 @@ instance jsonCodecRecordRequiredOptional ::
   jsonCodec' name record' = Data.Codec.Argonaut.object name codec
     where
     codec :: Data.Codec.Argonaut.JPropCodec (Record required optional)
-    codec =
-      Data.Codec.GCodec
-        (Control.Monad.Reader.Trans.ReaderT decode)
-        (Data.Profunctor.Star.Star encode)
+    codec = Data.Codec.Codec decode encode
 
     decode ::
       Foreign.Object.Object Data.Argonaut.Core.Json ->
@@ -1442,13 +1436,16 @@ instance jsonCodecRecordRequiredOptional ::
 
     encode ::
       Record required optional ->
-      Control.Monad.Writer.Writer
+      Data.Tuple.Tuple
         (Data.List.List (Data.Tuple.Tuple String Data.Argonaut.Core.Json))
         (Record required optional)
-    encode record = do
-      Control.Monad.Writer.Class.tell (Data.Codec.encode requiredCodec (required record))
-      Control.Monad.Writer.Class.tell (Data.Codec.encode optionalCodec (optional record))
-      pure record
+    encode record =
+      Data.Tuple.Tuple
+        (
+          (Data.Codec.encode requiredCodec (required record))
+          <> (Data.Codec.encode optionalCodec (optional record))
+        )
+        record
 
     optionalCodec :: Data.Codec.Argonaut.JPropCodec (Option optional)
     optionalCodec = jsonCodecOption optionalProxy record'
@@ -1459,14 +1456,14 @@ instance jsonCodecRecordRequiredOptional ::
     requiredCodec :: Data.Codec.Argonaut.JPropCodec (Prim.Record required)
     requiredCodec = jsonCodecRequired requiredProxy record'
 
-    requiredProxy :: Type.Data.RowList.RLProxy requiredList
-    requiredProxy = Type.Data.RowList.RLProxy
+    requiredProxy :: Type.Proxy.Proxy requiredList
+    requiredProxy = Type.Proxy.Proxy
 
 -- | A typeclass that iterates a `RowList` converting a record of `JsonCodec`s into a `JsonCodec` for an option.
 class JsonCodecOption (list :: Prim.RowList.RowList Type) (record :: Row Type) (option :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   jsonCodecOption ::
     forall proxy.
     proxy list ->
@@ -1480,9 +1477,9 @@ instance jsonCodecOptionNil :: JsonCodecOption Prim.RowList.Nil record option wh
     Prim.Record record ->
     Data.Codec.Argonaut.JPropCodec (Option option)
   jsonCodecOption _ _ =
-    Data.Codec.mapCodec
-      (\_ -> Data.Either.Right empty)
-      (\_ -> {})
+    Data.Profunctor.dimap
+      mempty
+      (\_ -> empty)
       Data.Codec.Argonaut.record
 else instance jsonCodecOptionCons ::
   ( Data.Symbol.IsSymbol label
@@ -1497,10 +1494,7 @@ else instance jsonCodecOptionCons ::
     proxy (Prim.RowList.Cons label value list) ->
     Prim.Record record ->
     Data.Codec.Argonaut.JPropCodec (Option option)
-  jsonCodecOption _ record =
-    Data.Codec.GCodec
-      (Control.Monad.Reader.Trans.ReaderT decode)
-      (Data.Profunctor.Star.Star encode)
+  jsonCodecOption _ record = Data.Codec.Codec decode encode
     where
     codec :: Data.Codec.Argonaut.JsonCodec value
     codec = Record.get label record
@@ -1520,25 +1514,24 @@ else instance jsonCodecOptionCons ::
 
     encode ::
       Option option ->
-      Control.Monad.Writer.Writer (Data.List.List (Data.Tuple.Tuple String Data.Argonaut.Core.Json)) (Option option)
+      Data.Tuple.Tuple (Data.List.List (Data.Tuple.Tuple String Data.Argonaut.Core.Json)) (Option option)
     encode option = do
-      case get label option of
-        Data.Maybe.Just value ->
-          Control.Monad.Writer.Class.tell
-            ( Data.List.Cons
-                (Data.Tuple.Tuple key (Data.Codec.Argonaut.encode codec value))
-                Data.List.Nil
-            )
-        Data.Maybe.Nothing -> pure unit
-      Control.Monad.Writer.Class.tell
-        (Data.Codec.Argonaut.encode option' (delete label option))
-      pure option
+      Data.Tuple.Tuple
+        ( case get label option of
+            Data.Maybe.Just value ->
+              Data.List.Cons
+                  (Data.Tuple.Tuple key (Data.Codec.Argonaut.encode codec value))
+                  Data.List.Nil
+            Data.Maybe.Nothing -> mempty
+          <> (Data.Codec.Argonaut.encode option' (delete label option))
+        )
+        option
 
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option' :: Data.Codec.Argonaut.JPropCodec (Option option')
     option' = jsonCodecOption proxy record
@@ -1550,7 +1543,7 @@ else instance jsonCodecOptionCons ::
 class JsonCodecRequired (list :: Prim.RowList.RowList Type) (record :: Row Type) (required :: Row Type) | list -> record required where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   jsonCodecRequired ::
     forall proxy.
     proxy list ->
@@ -1563,11 +1556,7 @@ instance jsonCodecRequiredNil :: JsonCodecRequired Prim.RowList.Nil record () wh
     proxy Prim.RowList.Nil ->
     Prim.Record record ->
     Data.Codec.Argonaut.JPropCodec (Prim.Record ())
-  jsonCodecRequired _ _ =
-    Data.Codec.mapCodec
-      (\_ -> Data.Either.Right {})
-      (\_ -> {})
-      Data.Codec.Argonaut.record
+  jsonCodecRequired _ _ = Data.Codec.Argonaut.record
 else instance jsonCodecRequiredCons ::
   ( Data.Symbol.IsSymbol label
   , JsonCodecRequired list record required'
@@ -1581,10 +1570,7 @@ else instance jsonCodecRequiredCons ::
     proxy (Prim.RowList.Cons label value list) ->
     Prim.Record record ->
     Data.Codec.Argonaut.JPropCodec (Prim.Record required)
-  jsonCodecRequired _ record =
-    Data.Codec.GCodec
-      (Control.Monad.Reader.Trans.ReaderT decode)
-      (Data.Profunctor.Star.Star encode)
+  jsonCodecRequired _ record = Data.Codec.Codec decode encode
     where
     codec :: Data.Codec.Argonaut.JsonCodec value
     codec = Record.get label record
@@ -1602,22 +1588,20 @@ else instance jsonCodecRequiredCons ::
 
     encode ::
       Prim.Record required ->
-      Control.Monad.Writer.Writer (Data.List.List (Data.Tuple.Tuple String Data.Argonaut.Core.Json)) (Prim.Record required)
-    encode required' = do
-      Control.Monad.Writer.Class.tell
+      Data.Tuple.Tuple (Data.List.List (Data.Tuple.Tuple String Data.Argonaut.Core.Json)) (Prim.Record required)
+    encode required' =
+      Data.Tuple.Tuple
         ( Data.List.Cons
             (Data.Tuple.Tuple key (Data.Codec.Argonaut.encode codec (Record.get label required')))
             Data.List.Nil
         )
-      Control.Monad.Writer.Class.tell
-        (Data.Codec.Argonaut.encode requiredCodec (Record.delete label required'))
-      pure required'
+        required'
 
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     requiredCodec :: Data.Codec.Argonaut.JPropCodec (Prim.Record required')
     requiredCodec = jsonCodecRequired proxy record
@@ -1634,7 +1618,7 @@ else instance jsonCodecRequiredCons ::
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.modify'' { bar: \x -> x + 1 } someOption
@@ -1695,8 +1679,8 @@ else instance modifyOptionCons ::
     Data.Maybe.Just value -> insert label (recordValue value) option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -1720,7 +1704,7 @@ class
   (EqOption list option) <= OrdOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   compareOption ::
     forall proxy.
     proxy list ->
@@ -1754,8 +1738,8 @@ else instance ordOptionCons ::
     GT -> GT
     LT -> LT
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     leftValue :: Data.Maybe.Maybe value
     leftValue = get label left
@@ -1801,7 +1785,7 @@ else instance partitionConsAnyConsAnyAny ::
 class ReadForeignOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   readImplOption ::
     forall proxy.
     proxy list ->
@@ -1858,8 +1842,8 @@ else instance readForeignOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     option' :: Foreign.F (Option option')
     option' = readImplOption proxy foreign'
@@ -1875,7 +1859,7 @@ else instance readForeignOptionCons ::
 -- | someRecord = Option.recordFromRecord { foo: true }
 -- |
 -- | anotherRecord :: Option.Record ( foo :: Boolean ) ( bar2 :: Int )
--- | anotherRecord = Option.rename' { bar: Data.Symbol.SProxy :: _ "bar2" } someRecord
+-- | anotherRecord = Option.rename' { bar: Type.Proxy.Proxy :: _ "bar2" } someRecord
 -- | ```
 class Rename (record :: Row Type) (requiredInput :: Row Type) (optionalInput :: Row Type) (requiredOutput :: Row Type) (optionalOutput :: Row Type) where
   rename' ::
@@ -1948,14 +1932,14 @@ else instance renameOptionalCons ::
     Data.Maybe.Just value -> insert newLabel value newOptional
     Data.Maybe.Nothing -> insertField newLabel newOptional
     where
-    newLabel :: Data.Symbol.SProxy newLabel
-    newLabel = Data.Symbol.SProxy
+    newLabel :: Type.Proxy.Proxy newLabel
+    newLabel = Type.Proxy.Proxy
 
     newOptional :: Option newOptional'
     newOptional = renameOptional proxy record oldOptional'
 
-    oldLabel :: Data.Symbol.SProxy oldLabel
-    oldLabel = Data.Symbol.SProxy
+    oldLabel :: Type.Proxy.Proxy oldLabel
+    oldLabel = Type.Proxy.Proxy
 
     oldOptional' :: Option oldOptional'
     oldOptional' = delete oldLabel oldOptional
@@ -2003,14 +1987,14 @@ else instance renameRequiredCons ::
     Prim.Record newRequired
   renameRequired _ record oldRequired = Record.insert newLabel value newRequired
     where
-    newLabel :: Data.Symbol.SProxy newLabel
-    newLabel = Data.Symbol.SProxy
+    newLabel :: Type.Proxy.Proxy newLabel
+    newLabel = Type.Proxy.Proxy
 
     newRequired :: Prim.Record newRequired'
     newRequired = renameRequired proxy record oldRequired'
 
-    oldLabel :: Data.Symbol.SProxy oldLabel
-    oldLabel = Data.Symbol.SProxy
+    oldLabel :: Type.Proxy.Proxy oldLabel
+    oldLabel = Type.Proxy.Proxy
 
     oldRequired' :: Prim.Record oldRequired'
     oldRequired' = Record.delete oldLabel oldRequired
@@ -2105,8 +2089,8 @@ else instance setOptionConsMaybe ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -2137,8 +2121,8 @@ else instance setOptionCons ::
     Option option
   setOption _ record oldOption = insert label value option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -2188,8 +2172,8 @@ else instance setRequiredCons ::
     Prim.Record required
   setRequired _ record oldRequired = Record.insert label value newRequired
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     oldRequired' :: Prim.Record oldRequired'
     oldRequired' = Record.delete label oldRequired
@@ -2208,7 +2192,7 @@ else instance setRequiredCons ::
 class ShowOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   showOption ::
     forall proxy.
     proxy list ->
@@ -2241,8 +2225,8 @@ else instance showOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -2264,7 +2248,7 @@ else instance showOptionCons ::
 -- | ```
 -- | Instead of having to say:
 -- | ```PureScript
--- | Option.get (Data.Symbol.SProxy :: _ "foo") someOption
+-- | Option.get (Type.Proxy.Proxy :: _ "foo") someOption
 -- | ```
 -- |
 -- | Not only does it save a bunch of typing, it also mitigates the need for a direct dependency on `SProxy _`.
@@ -2320,7 +2304,7 @@ instance toRecordAny ::
 class ToRecordOption (list :: Prim.RowList.RowList Type) (option :: Row Type) (record :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   toRecordOption ::
     forall proxy.
     proxy list ->
@@ -2353,8 +2337,8 @@ else instance toRecordOptionCons ::
     first :: Record.Builder.Builder (Prim.Record record') (Prim.Record record)
     first = Record.Builder.insert label value
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -2369,7 +2353,7 @@ else instance toRecordOptionCons ::
 class WriteForeignOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   writeForeignOption ::
     forall proxy.
     proxy list ->
@@ -2408,8 +2392,8 @@ else instance writeForeignOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Type.Proxy.Proxy label
+    label = Type.Proxy.Proxy
 
     object :: Foreign.Object.Object Foreign.Foreign
     object = Foreign.unsafeFromForeign foreign'
@@ -2429,7 +2413,7 @@ else instance writeForeignOptionCons ::
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.alter { bar: \_ -> Data.Maybe.Just 41 } someOption
@@ -2459,7 +2443,7 @@ alter' f _ (Option object) = { option, value }
   go value' = to (f (from value'))
 
   key :: String
-  key = Data.Symbol.reflectSymbol (Data.Symbol.SProxy :: Data.Symbol.SProxy label)
+  key = Data.Symbol.reflectSymbol (Type.Proxy.Proxy :: Type.Proxy.Proxy label)
 
   option :: Option option
   option = Option (Foreign.Object.alter go key object)
@@ -2477,12 +2461,12 @@ alter' f _ (Option object) = { option, value }
 -- | someOption = Option.fromRecord { foo: true, bar: 31 }
 -- |
 -- | anotherOption :: Option.Option ( bar :: Int )
--- | anotherOption = Option.delete (Data.Symbol.SProxy :: _ "foo") someOption
+-- | anotherOption = Option.delete (Type.Proxy.Proxy :: _ "foo") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 delete ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2568,15 +2552,15 @@ fromRecord record' = optional record
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | bar :: Data.Maybe.Maybe Int
--- | bar = Option.get (Data.Symbol.SProxy :: _ "bar") someOption
+-- | bar = Option.get (Type.Proxy.Proxy :: _ "bar") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 get ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2640,7 +2624,7 @@ get' record option = get'' record option
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | -- This will be `Nothing` because the key `foo` does not exist in the option.
 -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
@@ -2648,7 +2632,7 @@ get' record option = get'' record option
 -- |
 -- | -- This will be `Just { foo: true, bar: 31 }` because all keys exist in the option.
 -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
--- | bar = Option.getAll (Option.insert (Data.Symbol.SProxy :: _ "foo") true someOption)
+-- | bar = Option.getAll (Option.insert (Type.Proxy.Proxy :: _ "foo") true someOption)
 -- | ```
 getAll ::
   forall option record.
@@ -2666,15 +2650,15 @@ getAll = getAll'
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | bar :: Int
--- | bar = Option.getWithDefault 13 (Data.Symbol.SProxy :: _ "bar") someOption
+-- | bar = Option.getWithDefault 13 (Type.Proxy.Proxy :: _ "bar") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 getWithDefault ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2697,12 +2681,12 @@ getWithDefault default proxy option = case get proxy option of
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 someOption
+-- | anotherOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 insert ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2727,12 +2711,12 @@ insert proxy value option = (alter' go proxy option).option
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.insertField (Data.Symbol.SProxy :: _ "bar") someOption
+-- | anotherOption = Option.insertField (Type.Proxy.Proxy :: _ "bar") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 insertField ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2780,7 +2764,7 @@ jsonCodec ::
   String ->
   Prim.Record record ->
   Data.Codec.Argonaut.JsonCodec (Option optional)
-jsonCodec name record' = Data.Codec.basicCodec decode encode
+jsonCodec name record' = Data.Codec.codec decode encode
   where
   codec :: Data.Codec.Argonaut.JsonCodec (Record () optional)
   codec = jsonCodec' name record'
@@ -2843,15 +2827,15 @@ jsonCodecRecord name record' = jsonCodec' name record'
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.modify (Data.Symbol.SProxy :: _ "bar") (_ + 1) someOption
+-- | anotherOption = Option.modify (Type.Proxy.Proxy :: _ "bar") (_ + 1) someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 modify ::
   forall label option option' option'' proxy value value'.
   Data.Symbol.IsSymbol label =>
@@ -2877,7 +2861,7 @@ modify proxy f option = (alter' go proxy option).option
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.modify' { bar: \x -> x + 1 } someOption
@@ -2966,7 +2950,7 @@ recordFromRecordAndOption record =
 -- | someRecord = Option.recordFromRecord { foo: false }
 -- |
 -- | anotherRecord :: Option.Record ( foo :: Boolean ) ( bar2 :: Int, qux :: String )
--- | anotherRecord = Option.recordRename { bar: Data.Symbol.SProxy :: _ "bar2" } someRecord
+-- | anotherRecord = Option.recordRename { bar: Type.Proxy.Proxy :: _ "bar2" } someRecord
 -- | ```
 recordRename ::
   forall optional optional' record required required'.
@@ -3024,7 +3008,7 @@ recordToRecord record = toRecord' record
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar2 :: Int, qux :: String )
--- | anotherOption = Option.rename { bar: Data.Symbol.SProxy :: _ "bar2" } someOption
+-- | anotherOption = Option.rename { bar: Type.Proxy.Proxy :: _ "bar2" } someOption
 -- | ```
 rename ::
   forall optional optional' record.
@@ -3071,12 +3055,12 @@ required record' = case record' of
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.set (Data.Symbol.SProxy :: _ "bar") 31 someOption
+-- | anotherOption = Option.set (Type.Proxy.Proxy :: _ "bar") 31 someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 set ::
   forall label option option' option'' proxy value value'.
   Data.Symbol.IsSymbol label =>
@@ -3208,22 +3192,22 @@ user :: User
 user = empty
 
 age :: Data.Maybe.Maybe Int
-age = get (Data.Symbol.SProxy :: _ "age") user
+age = get (Type.Proxy.Proxy :: _ "age") user
 
 user1 :: User
-user1 = set (Data.Symbol.SProxy :: _ "age") 12 user
+user1 = set (Type.Proxy.Proxy :: _ "age") 12 user
 
 user2 :: Option ( username :: String, age :: Int, height :: Int )
-user2 = insert (Data.Symbol.SProxy :: _ "height") 12 user
+user2 = insert (Type.Proxy.Proxy :: _ "height") 12 user
 
 user3 :: Option ( username :: String, age :: Boolean )
-user3 = set (Data.Symbol.SProxy :: _ "age") true user
+user3 = set (Type.Proxy.Proxy :: _ "age") true user
 
 user4 :: Option ( username :: String )
-user4 = delete (Data.Symbol.SProxy :: _ "age") user
+user4 = delete (Type.Proxy.Proxy :: _ "age") user
 
 user5 :: Option ( username :: String, age :: Boolean )
-user5 = modify (Data.Symbol.SProxy :: _ "age") (\_ -> true) user
+user5 = modify (Type.Proxy.Proxy :: _ "age") (\_ -> true) user
 
 user6 :: User
 user6 = fromRecord {}
@@ -3289,10 +3273,10 @@ user26 :: User
 user26 = fromRecord { age: Data.Maybe.Nothing, username: Data.Maybe.Nothing }
 
 user27 :: Option ( age1 :: Int, username :: String )
-user27 = rename { age: Data.Symbol.SProxy :: Data.Symbol.SProxy "age1" } user
+user27 = rename { age: Type.Proxy.Proxy :: Type.Proxy.Proxy "age1" } user
 
 user28 :: Option ( age :: Int, username2 :: String )
-user28 = rename { username: Data.Symbol.SProxy :: Data.Symbol.SProxy "username2" } user
+user28 = rename { username: Type.Proxy.Proxy :: Type.Proxy.Proxy "username2" } user
 
 type Greeting
   = Record ( name :: String ) ( title :: String )
@@ -3319,4 +3303,4 @@ greeting7 :: Greeting
 greeting7 = recordSet { name: "Chris", title: Data.Maybe.Nothing } greeting1
 
 greeting8 :: Record ( "Name" :: String ) ( "Title" :: String )
-greeting8 = recordRename { name: Data.Symbol.SProxy :: Data.Symbol.SProxy "Name", title: Data.Symbol.SProxy :: Data.Symbol.SProxy "Title" } greeting1
+greeting8 = recordRename { name: Type.Proxy.Proxy :: Type.Proxy.Proxy "Name", title: Type.Proxy.Proxy :: Type.Proxy.Proxy "Title" } greeting1

--- a/test/HowTo.MakeAFunctionWithOptionalValues.purs
+++ b/test/HowTo.MakeAFunctionWithOptionalValues.purs
@@ -6,21 +6,21 @@ module HowTo.MakeAFunctionWithOptionalValues
 
 import Prelude
 import Data.Maybe as Data.Maybe
-import Data.Symbol as Data.Symbol
 import Option as Option
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
+import Type.Proxy as Type.Proxy
 
 greeting :: Option.Option ( name :: String, title :: String ) -> String
 greeting option = "Hello, " <> title' <> name'
   where
   name' :: String
-  name' = case Option.get (Data.Symbol.SProxy :: _ "name") option of
+  name' = case Option.get (Type.Proxy.Proxy :: _ "name") option of
     Data.Maybe.Just name -> name
     Data.Maybe.Nothing -> "World"
 
   title' :: String
-  title' = case Option.get (Data.Symbol.SProxy :: _ "title") option of
+  title' = case Option.get (Type.Proxy.Proxy :: _ "title") option of
     Data.Maybe.Just title -> title <> " "
     Data.Maybe.Nothing -> ""
 

--- a/test/HowTo.MakeAFunctionWithOptionalValuesFromARecord.purs
+++ b/test/HowTo.MakeAFunctionWithOptionalValuesFromARecord.purs
@@ -6,10 +6,10 @@ module HowTo.MakeAFunctionWithOptionalValuesFromARecord
 
 import Prelude
 import Data.Maybe as Data.Maybe
-import Data.Symbol as Data.Symbol
 import Option as Option
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
+import Type.Proxy as Type.Proxy
 
 greeting ::
   forall record.
@@ -19,7 +19,7 @@ greeting ::
 greeting record = "Hello, " <> title' <> name'
   where
   name' :: String
-  name' = case Option.get (Data.Symbol.SProxy :: _ "name") option of
+  name' = case Option.get (Type.Proxy.Proxy :: _ "name") option of
     Data.Maybe.Just name -> name
     Data.Maybe.Nothing -> "World"
 
@@ -27,7 +27,7 @@ greeting record = "Hello, " <> title' <> name'
   option = Option.fromRecord record
 
   title' :: String
-  title' = case Option.get (Data.Symbol.SProxy :: _ "title") option of
+  title' = case Option.get (Type.Proxy.Proxy :: _ "title") option of
     Data.Maybe.Just title -> title <> " "
     Data.Maybe.Nothing -> ""
 

--- a/test/HowTo.ProvideAnEasierAPIForDateTime.purs
+++ b/test/HowTo.ProvideAnEasierAPIForDateTime.purs
@@ -17,6 +17,7 @@ import Option as Option
 import Prim.Row as Prim.Row
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
+import Type.Proxy as Type.Proxy
 
 type Option
   = ( day :: Int
@@ -39,13 +40,13 @@ dateTime record = Data.DateTime.DateTime date time
   date = Data.Date.canonicalDate year month day
     where
     day :: Data.Date.Component.Day
-    day = get (Data.Symbol.SProxy :: _ "day")
+    day = get (Type.Proxy.Proxy :: _ "day")
 
     month :: Data.Date.Component.Month
-    month = Option.getWithDefault bottom (Data.Symbol.SProxy :: _ "month") options
+    month = Option.getWithDefault bottom (Type.Proxy.Proxy :: _ "month") options
 
     year :: Data.Date.Component.Year
-    year = get (Data.Symbol.SProxy :: _ "year")
+    year = get (Type.Proxy.Proxy :: _ "year")
 
   get ::
     forall label proxy record' value.
@@ -65,16 +66,16 @@ dateTime record = Data.DateTime.DateTime date time
   time = Data.Time.Time hour minute second millisecond
     where
     hour :: Data.Time.Component.Hour
-    hour = get (Data.Symbol.SProxy :: _ "hour")
+    hour = get (Type.Proxy.Proxy :: _ "hour")
 
     minute :: Data.Time.Component.Minute
-    minute = get (Data.Symbol.SProxy :: _ "minute")
+    minute = get (Type.Proxy.Proxy :: _ "minute")
 
     millisecond :: Data.Time.Component.Millisecond
-    millisecond = get (Data.Symbol.SProxy :: _ "millisecond")
+    millisecond = get (Type.Proxy.Proxy :: _ "millisecond")
 
     second :: Data.Time.Component.Second
-    second = get (Data.Symbol.SProxy :: _ "second")
+    second = get (Type.Proxy.Proxy :: _ "second")
 
 spec :: Test.Spec.Spec Unit
 spec =


### PR DESCRIPTION
We move to the latest version of everything.

Since v0.15.15 is the most recent stable version at the time of writing, that's the one we use.

Making this update required some minor implementation changes to get the types to line up, in particular the change from `Data.Codec.GCodec` to `Data.Codec.Codec`.

This is a breaking change and will require a major version bump.

I would like to submit a follow-up PR changing from a proxy-based API to one that uses visible type applications which would be another breaking change. It may make sense to include that change before a major release.