### PR TITLE
Use a poly-kinded `Proxy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ greeting :: Option.Option ( name :: String, title :: String ) -> String
 greeting option = "Hello, " <> title' <> name'
   where
   name' :: String
-  name' = case Option.get (Data.Symbol.SProxy :: _ "name") option of
+  name' = case Option.get (Type.Proxy.Proxy :: _ "name") option of
     Data.Maybe.Just name -> name
     Data.Maybe.Nothing -> "World"
 
   title' :: String
-  title' = case Option.get (Data.Symbol.SProxy :: _ "title") option of
+  title' = case Option.get (Type.Proxy.Proxy :: _ "title") option of
     Data.Maybe.Just title -> title <> " "
     Data.Maybe.Nothing -> ""
 ```
@@ -144,7 +144,7 @@ greeting ::
 greeting record = "Hello, " <> title' <> name'
   where
   name' :: String
-  name' = case Option.get (Data.Symbol.SProxy :: _ "name") option of
+  name' = case Option.get (Type.Proxy.Proxy :: _ "name") option of
     Data.Maybe.Just name -> name
     Data.Maybe.Nothing -> "World"
 
@@ -152,7 +152,7 @@ greeting record = "Hello, " <> title' <> name'
   option = Option.fromRecord record
 
   title' :: String
-  title' = case Option.get (Data.Symbol.SProxy :: _ "title") option of
+  title' = case Option.get (Type.Proxy.Proxy :: _ "title") option of
     Data.Maybe.Just title -> title <> " "
     Data.Maybe.Nothing -> ""
 ```
@@ -717,7 +717,7 @@ optionalField ::
   Data.Symbol.IsSymbol label =>
   Prim.Row.Cons label (Data.Maybe.Maybe value) record' record =>
   Prim.Row.Lacks label record' =>
-  Data.Symbol.SProxy label ->
+  Type.Proxy.Proxy label ->
   Data.Codec.Argonaut.JsonCodec value ->
   Data.Codec.Argonaut.JPropCodec (Record record') ->
   Data.Codec.Argonaut.JPropCodec (Record record)
@@ -774,8 +774,8 @@ jsonCodec''' :: Data.Codec.Argonaut.JsonCodec (Record ( name :: Data.Maybe.Maybe
 jsonCodec''' =
   Data.Codec.Argonaut.object
     "Greeting"
-    ( optionalField (Data.Symbol.SProxy :: _ "name") Data.Codec.Argonaut.string
-        $ optionalField (Data.Symbol.SProxy :: _ "title") Data.Codec.Argonaut.string
+    ( optionalField (Type.Proxy.Proxy :: _ "name") Data.Codec.Argonaut.string
+        $ optionalField (Type.Proxy.Proxy :: _ "title") Data.Codec.Argonaut.string
         $ Data.Codec.Argonaut.record
     )
 
@@ -1362,18 +1362,18 @@ import Control.Monad.Writer.Class as Control.Monad.Writer.Class
 import Data.Codec as Data.Codec
 import Data.List as Data.List
 import Data.Profunctor.Star as Data.Profunctor.Star
-import Data.Symbol as Data.Symbol
 import Data.Tuple as Data.Tuple
 import Foreign.Object as Foreign.Object
 import Prim.Row as Prim.Row
 import Record as Record
+import Type.Proxy as Type.Proxy
 
 optionalField ::
   forall label record record' value.
   Data.Symbol.IsSymbol label =>
   Prim.Row.Cons label (Data.Maybe.Maybe value) record' record =>
   Prim.Row.Lacks label record' =>
-  Data.Symbol.SProxy label ->
+  Type.Proxy.Proxy label ->
   Data.Codec.Argonaut.JsonCodec value ->
   Data.Codec.Argonaut.JPropCodec (Record record') ->
   Data.Codec.Argonaut.JPropCodec (Record record)
@@ -1430,8 +1430,8 @@ jsonCodec''' :: Data.Codec.Argonaut.JsonCodec (Record ( name :: String, title ::
 jsonCodec''' =
   Data.Codec.Argonaut.object
     "Greeting"
-    ( Data.Codec.Argonaut.recordProp (Data.Symbol.SProxy :: _ "name") Data.Codec.Argonaut.string
-        $ optionalField (Data.Symbol.SProxy :: _ "title") Data.Codec.Argonaut.string
+    ( Data.Codec.Argonaut.recordProp (Type.Proxy.Proxy :: _ "name") Data.Codec.Argonaut.string
+        $ optionalField (Type.Proxy.Proxy :: _ "title") Data.Codec.Argonaut.string
         $ Data.Codec.Argonaut.record
     )
 
@@ -1670,13 +1670,13 @@ dateTime record = Data.DateTime.DateTime date time
   date = Data.Date.canonicalDate year month day
     where
     day :: Data.Date.Component.Day
-    day = get (Data.Symbol.SProxy :: _ "day")
+    day = get (Type.Proxy.Proxy :: _ "day")
 
     month :: Data.Date.Component.Month
-    month = Option.getWithDefault bottom (Data.Symbol.SProxy :: _ "month") options
+    month = Option.getWithDefault bottom (Type.Proxy.Proxy :: _ "month") options
 
     year :: Data.Date.Component.Year
-    year = get (Data.Symbol.SProxy :: _ "year")
+    year = get (Type.Proxy.Proxy :: _ "year")
 
   get ::
     forall label proxy record' value.
@@ -1696,16 +1696,16 @@ dateTime record = Data.DateTime.DateTime date time
   time = Data.Time.Time hour minute second millisecond
     where
     hour :: Data.Time.Component.Hour
-    hour = get (Data.Symbol.SProxy :: _ "hour")
+    hour = get (Type.Proxy.Proxy :: _ "hour")
 
     minute :: Data.Time.Component.Minute
-    minute = get (Data.Symbol.SProxy :: _ "minute")
+    minute = get (Type.Proxy.Proxy :: _ "minute")
 
     millisecond :: Data.Time.Component.Millisecond
-    millisecond = get (Data.Symbol.SProxy :: _ "millisecond")
+    millisecond = get (Type.Proxy.Proxy :: _ "millisecond")
 
     second :: Data.Time.Component.Second
-    second = get (Data.Symbol.SProxy :: _ "second")
+    second = get (Type.Proxy.Proxy :: _ "second")
 ```
 
 Now, we can construct a `Data.DateTime.DateTime` fairly easily:
@@ -1751,10 +1751,10 @@ Instead of having to say:
 
 ```PureScript
 Option.insert
-  (Data.Symbol.SProxy :: _ "foo")
+  (Type.Proxy.Proxy :: _ "foo")
   true
   ( Option.insert
-      (Data.Symbol.SProxy :: _ "bar")
+      (Type.Proxy.Proxy :: _ "bar")
       31
       Option.empty
   )

--- a/src/Option.purs
+++ b/src/Option.purs
@@ -491,7 +491,7 @@ instance writeForeignRecordRequiredOptional ::
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.alter'' { bar: \_ -> Data.Maybe.Just 41 } someOption
@@ -576,7 +576,7 @@ else instance alterOptionCons ::
 class DecodeJsonOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   decodeJsonOption ::
     forall proxy.
     proxy list ->
@@ -699,7 +699,7 @@ else instance deleteOptionCons ::
 class EncodeJsonOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   encodeJsonOption ::
     forall proxy.
     proxy list ->
@@ -753,7 +753,7 @@ else instance encodeJsonOptionCons ::
 class EqOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   eqOption ::
     forall proxy.
     proxy list ->
@@ -816,10 +816,10 @@ else instance eqOptionCons ::
 -- | Instead of having to say:
 -- | ```PureScript
 -- | Option.insert
--- |   (Data.Symbol.SProxy :: _ "foo")
+-- |   (Type.Proxy.Proxy :: _ "foo")
 -- |   true
 -- |   ( Option.insert
--- |       (Data.Symbol.SProxy :: _ "bar")
+-- |       (Type.Proxy.Proxy :: _ "bar")
 -- |       31
 -- |       Option.empty
 -- |   )
@@ -887,7 +887,7 @@ instance fromRecordAny ::
 class FromRecordOption (list :: Prim.RowList.RowList Type) (record :: Row Type) (option :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   fromRecordOption ::
     forall proxy.
     proxy list ->
@@ -960,7 +960,7 @@ else instance fromRecordOptionCons ::
 class FromRecordRequired (list :: Prim.RowList.RowList Type) (record :: Row Type) (required :: Row Type) | list -> required record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   fromRecordRequired ::
     forall proxy.
     proxy list ->
@@ -1058,7 +1058,7 @@ instance getAny ::
 class GetOption (list :: Prim.RowList.RowList Type) (record' :: Row Type) (option :: Row Type) (record :: Row Type) | list -> record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   getOption ::
     forall proxy.
     proxy list ->
@@ -1177,7 +1177,7 @@ class GetAll (option :: Row Type) (record :: Row Type) | option -> record where
   -- | E.g.
   -- | ```PureScript
   -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
-  -- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+  -- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
   -- |
   -- | -- This will be `Nothing` because the key `foo` does not exist in the option.
   -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
@@ -1185,7 +1185,7 @@ class GetAll (option :: Row Type) (record :: Row Type) | option -> record where
   -- |
   -- | -- This will be `Just { foo: true, bar: 31 }` because all keys exist in the option.
   -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
-  -- | bar = Option.getAll' (Option.insert (Data.Symbol.SProxy :: _ "foo") true someOption)
+  -- | bar = Option.getAll' (Option.insert (Type.Proxy.Proxy :: _ "foo") true someOption)
   -- | ```
   getAll' ::
     Option option ->
@@ -1207,7 +1207,7 @@ instance getAllAny ::
 class GetAllOption (list :: Prim.RowList.RowList Type) (option :: Row Type) (record :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   getAllOption ::
     forall proxy.
     proxy list ->
@@ -1463,7 +1463,7 @@ instance jsonCodecRecordRequiredOptional ::
 class JsonCodecOption (list :: Prim.RowList.RowList Type) (record :: Row Type) (option :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   jsonCodecOption ::
     forall proxy.
     proxy list ->
@@ -1547,7 +1547,7 @@ else instance jsonCodecOptionCons ::
 class JsonCodecRequired (list :: Prim.RowList.RowList Type) (record :: Row Type) (required :: Row Type) | list -> record required where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   jsonCodecRequired ::
     forall proxy.
     proxy list ->
@@ -1631,7 +1631,7 @@ else instance jsonCodecRequiredCons ::
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.modify'' { bar: \x -> x + 1 } someOption
@@ -1720,7 +1720,7 @@ class
   | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   compareOption ::
     forall proxy.
     proxy list ->
@@ -1801,7 +1801,7 @@ else instance partitionConsAnyConsAnyAny ::
 class ReadForeignOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   readImplOption ::
     forall proxy.
     proxy list ->
@@ -1875,7 +1875,7 @@ else instance readForeignOptionCons ::
 -- | someRecord = Option.recordFromRecord { foo: true }
 -- |
 -- | anotherRecord :: Option.Record ( foo :: Boolean ) ( bar2 :: Int )
--- | anotherRecord = Option.rename' { bar: Data.Symbol.SProxy :: _ "bar2" } someRecord
+-- | anotherRecord = Option.rename' { bar: Type.Proxy.Proxy :: _ "bar2" } someRecord
 -- | ```
 class Rename (record :: Row Type) (requiredInput :: Row Type) (optionalInput :: Row Type) (requiredOutput :: Row Type) (optionalOutput :: Row Type) where
   rename' ::
@@ -2208,7 +2208,7 @@ else instance setRequiredCons ::
 class ShowOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   showOption ::
     forall proxy.
     proxy list ->
@@ -2264,7 +2264,7 @@ else instance showOptionCons ::
 -- | ```
 -- | Instead of having to say:
 -- | ```PureScript
--- | Option.get (Data.Symbol.SProxy :: _ "foo") someOption
+-- | Option.get (Type.Proxy.Proxy :: _ "foo") someOption
 -- | ```
 -- |
 -- | Not only does it save a bunch of typing, it also mitigates the need for a direct dependency on `SProxy _`.
@@ -2320,7 +2320,7 @@ instance toRecordAny ::
 class ToRecordOption (list :: Prim.RowList.RowList Type) (option :: Row Type) (record :: Row Type) | list -> option record where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   toRecordOption ::
     forall proxy.
     proxy list ->
@@ -2369,7 +2369,7 @@ else instance toRecordOptionCons ::
 class WriteForeignOption (list :: Prim.RowList.RowList Type) (option :: Row Type) | list -> option where
   -- | The `proxy` can be anything so long as its type variable has kind `Prim.RowList.RowList`.
   -- |
-  -- | It will commonly be `Type.Data.RowList.RLProxy`, but doesn't have to be.
+  -- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
   writeForeignOption ::
     forall proxy.
     proxy list ->
@@ -2429,7 +2429,7 @@ else instance writeForeignOptionCons ::
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.alter { bar: \_ -> Data.Maybe.Just 41 } someOption
@@ -2477,12 +2477,12 @@ alter' f _ (Option object) = { option, value }
 -- | someOption = Option.fromRecord { foo: true, bar: 31 }
 -- |
 -- | anotherOption :: Option.Option ( bar :: Int )
--- | anotherOption = Option.delete (Data.Symbol.SProxy :: _ "foo") someOption
+-- | anotherOption = Option.delete (Type.Proxy.Proxy :: _ "foo") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 delete ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2576,15 +2576,15 @@ fromRecord record' = optional record
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | bar :: Data.Maybe.Maybe Int
--- | bar = Option.get (Data.Symbol.SProxy :: _ "bar") someOption
+-- | bar = Option.get (Type.Proxy.Proxy :: _ "bar") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 get ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2648,7 +2648,7 @@ get' record option = get'' record option
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | -- This will be `Nothing` because the key `foo` does not exist in the option.
 -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
@@ -2656,7 +2656,7 @@ get' record option = get'' record option
 -- |
 -- | -- This will be `Just { foo: true, bar: 31 }` because all keys exist in the option.
 -- | bar :: Data.Maybe.Maybe (Record ( foo :: Boolean, bar :: Int))
--- | bar = Option.getAll (Option.insert (Data.Symbol.SProxy :: _ "foo") true someOption)
+-- | bar = Option.getAll (Option.insert (Type.Proxy.Proxy :: _ "foo") true someOption)
 -- | ```
 getAll ::
   forall option record.
@@ -2674,15 +2674,15 @@ getAll = getAll'
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | bar :: Int
--- | bar = Option.getWithDefault 13 (Data.Symbol.SProxy :: _ "bar") someOption
+-- | bar = Option.getWithDefault 13 (Type.Proxy.Proxy :: _ "bar") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 getWithDefault ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2705,12 +2705,12 @@ getWithDefault default proxy option = case get proxy option of
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 someOption
+-- | anotherOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 insert ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2735,12 +2735,12 @@ insert proxy value option = (alter' go proxy option).option
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.insertField (Data.Symbol.SProxy :: _ "bar") someOption
+-- | anotherOption = Option.insertField (Type.Proxy.Proxy :: _ "bar") someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 insertField ::
   forall label option option' proxy value.
   Data.Symbol.IsSymbol label =>
@@ -2851,15 +2851,15 @@ jsonCodecRecord name record' = jsonCodec' name record'
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.modify (Data.Symbol.SProxy :: _ "bar") (_ + 1) someOption
+-- | anotherOption = Option.modify (Type.Proxy.Proxy :: _ "bar") (_ + 1) someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 modify ::
   forall label option option' option'' proxy value value'.
   Data.Symbol.IsSymbol label =>
@@ -2885,7 +2885,7 @@ modify proxy f option = (alter' go proxy option).option
 -- | E.g.
 -- | ```PureScript
 -- | someOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | someOption = Option.insert (Data.Symbol.SProxy :: _ "bar") 31 Option.empty
+-- | someOption = Option.insert (Type.Proxy.Proxy :: _ "bar") 31 Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
 -- | anotherOption = Option.modify' { bar: \x -> x + 1 } someOption
@@ -2974,7 +2974,7 @@ recordFromRecordAndOption record =
 -- | someRecord = Option.recordFromRecord { foo: false }
 -- |
 -- | anotherRecord :: Option.Record ( foo :: Boolean ) ( bar2 :: Int, qux :: String )
--- | anotherRecord = Option.recordRename { bar: Data.Symbol.SProxy :: _ "bar2" } someRecord
+-- | anotherRecord = Option.recordRename { bar: Type.Proxy.Proxy :: _ "bar2" } someRecord
 -- | ```
 recordRename ::
   forall optional optional' record required required'.
@@ -3032,7 +3032,7 @@ recordToRecord record = toRecord' record
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar2 :: Int, qux :: String )
--- | anotherOption = Option.rename { bar: Data.Symbol.SProxy :: _ "bar2" } someOption
+-- | anotherOption = Option.rename { bar: Type.Proxy.Proxy :: _ "bar2" } someOption
 -- | ```
 rename ::
   forall optional optional' record.
@@ -3079,12 +3079,12 @@ required record' = case record' of
 -- | someOption = Option.empty
 -- |
 -- | anotherOption :: Option.Option ( foo :: Boolean, bar :: Int )
--- | anotherOption = Option.set (Data.Symbol.SProxy :: _ "bar") 31 someOption
+-- | anotherOption = Option.set (Type.Proxy.Proxy :: _ "bar") 31 someOption
 -- | ```
 -- |
 -- | The `proxy` can be anything so long as its type variable has kind `Symbol`.
 -- |
--- | It will commonly be `Data.Symbol.SProxy`, but doesn't have to be.
+-- | It will commonly be `Type.Proxy.Proxy`, but doesn't have to be.
 set ::
   forall label option option' option'' proxy value value'.
   Data.Symbol.IsSymbol label =>

--- a/src/Option.purs
+++ b/src/Option.purs
@@ -152,16 +152,16 @@ import Prim.RowList as Prim.RowList
 import Record as Record
 import Record.Builder as Record.Builder
 import Simple.JSON as Simple.JSON
-import Type.Data.RowList as Type.Data.RowList
 import Unsafe.Coerce as Unsafe.Coerce
 
 -- | A collection of key/value pairs where any key and value may or may not exist.
 -- | E.g. `Option (foo :: Boolean, bar :: Int)` means that either only `foo` exists with a value, only `bar` exists with a value, both `foo` and `bar` exist with values, or neither `foo` nor `bar` exist.
 newtype Option (row :: Row Type) = Option (Foreign.Object.Object (forall a. a))
 
--- A local proxy for `Prim.RowList.RowList` so as not to impose a hard requirement on `Type.Data.RowList.RLProxy` in the typeclasses we define.
--- `Type.Data.RowList.RLProxy` can still be used by callers, but it's not a requirement.
-data Proxy (list :: Prim.RowList.RowList Type) = Proxy
+-- A local proxy for `Prim.RowList.RowList` so as not to impose a hard requirement on `Type.Proxy.Proxy` in the typeclasses we define.
+-- `Type.Proxy.Proxy` can still be used by callers, but it's not a requirement.
+data Proxy :: forall kind. kind -> Type
+data Proxy list = Proxy
 
 -- | This instance ignores keys that do not exist in the given JSON object.
 -- |
@@ -357,14 +357,14 @@ instance encodeJsonRecordRequiredOptional ::
     optionalJSON :: Foreign.Object.Object Data.Argonaut.Core.Json
     optionalJSON = encodeJsonOption optionalProxy (optional record)
 
-    optionalProxy :: Type.Data.RowList.RLProxy optionalList
-    optionalProxy = Type.Data.RowList.RLProxy
+    optionalProxy :: Proxy optionalList
+    optionalProxy = Proxy
 
     requiredJSON :: Foreign.Object.Object Data.Argonaut.Core.Json
     requiredJSON = Data.Argonaut.Encode.Class.gEncodeJson (required record) requiredProxy
 
-    requiredProxy :: Type.Data.RowList.RLProxy requiredList
-    requiredProxy = Type.Data.RowList.RLProxy
+    requiredProxy :: Proxy requiredList
+    requiredProxy = Proxy
 
 -- | For required fields:
 -- |
@@ -435,14 +435,14 @@ instance showRecord ::
     optionalFields :: Data.List.List String
     optionalFields = showOption optionalProxy (optional record')
 
-    optionalProxy :: Type.Data.RowList.RLProxy optionalList
-    optionalProxy = Type.Data.RowList.RLProxy
+    optionalProxy :: Proxy optionalList
+    optionalProxy = Proxy
 
     requiredFields :: Array String
     requiredFields = Data.Show.showRecordFields requiredProxy (required record')
 
-    requiredProxy :: Type.Data.RowList.RLProxy requiredList
-    requiredProxy = Type.Data.RowList.RLProxy
+    requiredProxy :: Proxy requiredList
+    requiredProxy = Proxy
 
 -- | For required fields:
 -- |
@@ -552,8 +552,8 @@ else instance alterOptionCons ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -614,8 +614,8 @@ else instance decodeJsonOptionCons ::
       option <- option'
       Data.Either.Right (insertField label option)
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     key :: String
     key = Data.Symbol.reflectSymbol label
@@ -686,8 +686,8 @@ else instance deleteOptionCons ::
     Option option
   deleteOption _ record option' = deleteOption proxy record option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option :: Option oldOption'
     option = delete label option'
@@ -740,8 +740,8 @@ else instance encodeJsonOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -784,8 +784,8 @@ else instance eqOptionCons ::
     Boolean
   eqOption _ left right = leftValue == rightValue && rest
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     leftValue :: Data.Maybe.Maybe value
     leftValue = get label left
@@ -918,8 +918,8 @@ else instance fromRecordOptionConsMaybe ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option :: Option option'
     option = fromRecordOption proxy record
@@ -944,8 +944,8 @@ else instance fromRecordOptionCons ::
     Option option
   fromRecordOption _ record = insert label value option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option :: Option option'
     option = fromRecordOption proxy record
@@ -992,8 +992,8 @@ else instance fromRecordRequiredCons ::
     first :: Record.Builder.Builder (Prim.Record required') (Prim.Record required)
     first = Record.Builder.insert label value
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -1080,8 +1080,8 @@ else instance getOptionConsFunction ::
   GetOption (Prim.RowList.Cons label (Data.Maybe.Maybe value -> result) list) givenRecord option record where
   getOption _ record' option = Record.insert label value record
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     optionValue :: Data.Maybe.Maybe value
     optionValue = get label option
@@ -1112,8 +1112,8 @@ else instance getOptionConsMaybe ::
     Data.Maybe.Just _ -> Record.insert label optionValue record
     Data.Maybe.Nothing -> Record.insert label recordValue record
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     optionValue :: Data.Maybe.Maybe value
     optionValue = get label option
@@ -1139,8 +1139,8 @@ else instance getOptionConsValue ::
     Data.Maybe.Just value -> Record.insert label value record
     Data.Maybe.Nothing -> Record.insert label recordValue record
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     optionValue :: Data.Maybe.Maybe value
     optionValue = get label option
@@ -1231,8 +1231,8 @@ else instance getAllOptionCons ::
       Data.Maybe.Nothing -> Data.Maybe.Nothing
     Data.Maybe.Nothing -> Data.Maybe.Nothing
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -1311,8 +1311,8 @@ else instance insertOptionConsMaybe ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option :: Option option'
     option = insertOption proxy record oldOption
@@ -1338,8 +1338,8 @@ else instance insertOptionConsValue ::
     Option option
   insertOption _ record oldOption = insert label value option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option :: Option option'
     option = insertOption proxy record oldOption
@@ -1456,8 +1456,8 @@ instance jsonCodecRecordRequiredOptional ::
     requiredCodec :: Data.Codec.Argonaut.JPropCodec (Prim.Record required)
     requiredCodec = jsonCodecRequired requiredProxy record'
 
-    requiredProxy :: Type.Data.RowList.RLProxy requiredList
-    requiredProxy = Type.Data.RowList.RLProxy
+    requiredProxy :: Proxy requiredList
+    requiredProxy = Proxy
 
 -- | A typeclass that iterates a `RowList` converting a record of `JsonCodec`s into a `JsonCodec` for an option.
 class JsonCodecOption (list :: Prim.RowList.RowList Type) (record :: Row Type) (option :: Row Type) | list -> option record where
@@ -1534,8 +1534,8 @@ else instance jsonCodecOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option' :: Data.Codec.Argonaut.JPropCodec (Option option')
     option' = jsonCodecOption proxy record
@@ -1613,8 +1613,8 @@ else instance jsonCodecRequiredCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     requiredCodec :: Data.Codec.Argonaut.JPropCodec (Prim.Record required')
     requiredCodec = jsonCodecRequired proxy record
@@ -1692,8 +1692,8 @@ else instance modifyOptionCons ::
     Data.Maybe.Just value -> insert label (recordValue value) option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -1754,8 +1754,8 @@ else instance ordOptionCons ::
     GT -> GT
     LT -> LT
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     leftValue :: Data.Maybe.Maybe value
     leftValue = get label left
@@ -1858,8 +1858,8 @@ else instance readForeignOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     option' :: Foreign.F (Option option')
     option' = readImplOption proxy foreign'
@@ -1948,14 +1948,14 @@ else instance renameOptionalCons ::
     Data.Maybe.Just value -> insert newLabel value newOptional
     Data.Maybe.Nothing -> insertField newLabel newOptional
     where
-    newLabel :: Data.Symbol.SProxy newLabel
-    newLabel = Data.Symbol.SProxy
+    newLabel :: Proxy newLabel
+    newLabel = Proxy
 
     newOptional :: Option newOptional'
     newOptional = renameOptional proxy record oldOptional'
 
-    oldLabel :: Data.Symbol.SProxy oldLabel
-    oldLabel = Data.Symbol.SProxy
+    oldLabel :: Proxy oldLabel
+    oldLabel = Proxy
 
     oldOptional' :: Option oldOptional'
     oldOptional' = delete oldLabel oldOptional
@@ -2003,14 +2003,14 @@ else instance renameRequiredCons ::
     Prim.Record newRequired
   renameRequired _ record oldRequired = Record.insert newLabel value newRequired
     where
-    newLabel :: Data.Symbol.SProxy newLabel
-    newLabel = Data.Symbol.SProxy
+    newLabel :: Proxy newLabel
+    newLabel = Proxy
 
     newRequired :: Prim.Record newRequired'
     newRequired = renameRequired proxy record oldRequired'
 
-    oldLabel :: Data.Symbol.SProxy oldLabel
-    oldLabel = Data.Symbol.SProxy
+    oldLabel :: Proxy oldLabel
+    oldLabel = Proxy
 
     oldRequired' :: Prim.Record oldRequired'
     oldRequired' = Record.delete oldLabel oldRequired
@@ -2105,8 +2105,8 @@ else instance setOptionConsMaybe ::
     Data.Maybe.Just value -> insert label value option
     Data.Maybe.Nothing -> insertField label option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -2137,8 +2137,8 @@ else instance setOptionCons ::
     Option option
   setOption _ record oldOption = insert label value option
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     oldOption' :: Option oldOption'
     oldOption' = delete label oldOption
@@ -2188,8 +2188,8 @@ else instance setRequiredCons ::
     Prim.Record required
   setRequired _ record oldRequired = Record.insert label value newRequired
     where
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     oldRequired' :: Prim.Record oldRequired'
     oldRequired' = Record.delete label oldRequired
@@ -2241,8 +2241,8 @@ else instance showOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -2353,8 +2353,8 @@ else instance toRecordOptionCons ::
     first :: Record.Builder.Builder (Prim.Record record') (Prim.Record record)
     first = Record.Builder.insert label value
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     proxy :: Proxy list
     proxy = Proxy
@@ -2408,8 +2408,8 @@ else instance writeForeignOptionCons ::
     key :: String
     key = Data.Symbol.reflectSymbol label
 
-    label :: Data.Symbol.SProxy label
-    label = Data.Symbol.SProxy
+    label :: Proxy label
+    label = Proxy
 
     object :: Foreign.Object.Object Foreign.Foreign
     object = Foreign.unsafeFromForeign foreign'
@@ -2459,7 +2459,7 @@ alter' f _ (Option object) = { option, value }
   go value' = to (f (from value'))
 
   key :: String
-  key = Data.Symbol.reflectSymbol (Data.Symbol.SProxy :: Data.Symbol.SProxy label)
+  key = Data.Symbol.reflectSymbol (Proxy :: _ label)
 
   option :: Option option
   option = Option (Foreign.Object.alter go key object)
@@ -3219,22 +3219,22 @@ user :: User
 user = empty
 
 age :: Data.Maybe.Maybe Int
-age = get (Data.Symbol.SProxy :: _ "age") user
+age = get (Proxy :: _ "age") user
 
 user1 :: User
-user1 = set (Data.Symbol.SProxy :: _ "age") 12 user
+user1 = set (Proxy :: _ "age") 12 user
 
 user2 :: Option (username :: String, age :: Int, height :: Int)
-user2 = insert (Data.Symbol.SProxy :: _ "height") 12 user
+user2 = insert (Proxy :: _ "height") 12 user
 
 user3 :: Option (username :: String, age :: Boolean)
-user3 = set (Data.Symbol.SProxy :: _ "age") true user
+user3 = set (Proxy :: _ "age") true user
 
 user4 :: Option (username :: String)
-user4 = delete (Data.Symbol.SProxy :: _ "age") user
+user4 = delete (Proxy :: _ "age") user
 
 user5 :: Option (username :: String, age :: Boolean)
-user5 = modify (Data.Symbol.SProxy :: _ "age") (\_ -> true) user
+user5 = modify (Proxy :: _ "age") (\_ -> true) user
 
 user6 :: User
 user6 = fromRecord {}
@@ -3300,10 +3300,10 @@ user26 :: User
 user26 = fromRecord { age: Data.Maybe.Nothing, username: Data.Maybe.Nothing }
 
 user27 :: Option (age1 :: Int, username :: String)
-user27 = rename { age: Data.Symbol.SProxy :: Data.Symbol.SProxy "age1" } user
+user27 = rename { age: Proxy :: _ "age1" } user
 
 user28 :: Option (age :: Int, username2 :: String)
-user28 = rename { username: Data.Symbol.SProxy :: Data.Symbol.SProxy "username2" } user
+user28 = rename { username: Proxy :: _ "username2" } user
 
 type Greeting = Record (name :: String) (title :: String)
 
@@ -3329,4 +3329,4 @@ greeting7 :: Greeting
 greeting7 = recordSet { name: "Chris", title: Data.Maybe.Nothing } greeting1
 
 greeting8 :: Record ("Name" :: String) ("Title" :: String)
-greeting8 = recordRename { name: Data.Symbol.SProxy :: Data.Symbol.SProxy "Name", title: Data.Symbol.SProxy :: Data.Symbol.SProxy "Title" } greeting1
+greeting8 = recordRename { name: Proxy :: _ "Name", title: Proxy :: _ "Title" } greeting1

--- a/test/HowTo.MakeAFunctionWithOptionalValues.purs
+++ b/test/HowTo.MakeAFunctionWithOptionalValues.purs
@@ -6,21 +6,21 @@ module HowTo.MakeAFunctionWithOptionalValues
 
 import Prelude
 import Data.Maybe as Data.Maybe
-import Data.Symbol as Data.Symbol
 import Option as Option
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
+import Type.Proxy as Type.Proxy
 
 greeting :: Option.Option (name :: String, title :: String) -> String
 greeting option = "Hello, " <> title' <> name'
   where
   name' :: String
-  name' = case Option.get (Data.Symbol.SProxy :: _ "name") option of
+  name' = case Option.get (Type.Proxy.Proxy :: _ "name") option of
     Data.Maybe.Just name -> name
     Data.Maybe.Nothing -> "World"
 
   title' :: String
-  title' = case Option.get (Data.Symbol.SProxy :: _ "title") option of
+  title' = case Option.get (Type.Proxy.Proxy :: _ "title") option of
     Data.Maybe.Just title -> title <> " "
     Data.Maybe.Nothing -> ""
 

--- a/test/HowTo.MakeAFunctionWithOptionalValuesFromARecord.purs
+++ b/test/HowTo.MakeAFunctionWithOptionalValuesFromARecord.purs
@@ -6,10 +6,10 @@ module HowTo.MakeAFunctionWithOptionalValuesFromARecord
 
 import Prelude
 import Data.Maybe as Data.Maybe
-import Data.Symbol as Data.Symbol
 import Option as Option
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
+import Type.Proxy as Type.Proxy
 
 greeting ::
   forall record.
@@ -19,7 +19,7 @@ greeting ::
 greeting record = "Hello, " <> title' <> name'
   where
   name' :: String
-  name' = case Option.get (Data.Symbol.SProxy :: _ "name") option of
+  name' = case Option.get (Type.Proxy.Proxy :: _ "name") option of
     Data.Maybe.Just name -> name
     Data.Maybe.Nothing -> "World"
 
@@ -27,7 +27,7 @@ greeting record = "Hello, " <> title' <> name'
   option = Option.fromRecord record
 
   title' :: String
-  title' = case Option.get (Data.Symbol.SProxy :: _ "title") option of
+  title' = case Option.get (Type.Proxy.Proxy :: _ "title") option of
     Data.Maybe.Just title -> title <> " "
     Data.Maybe.Nothing -> ""
 

--- a/test/HowTo.ProvideAnEasierAPIForDateTime.purs
+++ b/test/HowTo.ProvideAnEasierAPIForDateTime.purs
@@ -17,6 +17,7 @@ import Option as Option
 import Prim.Row as Prim.Row
 import Test.Spec as Test.Spec
 import Test.Spec.Assertions as Test.Spec.Assertions
+import Type.Proxy as Type.Proxy
 
 type Option =
   ( day :: Int
@@ -39,13 +40,13 @@ dateTime record = Data.DateTime.DateTime date time
   date = Data.Date.canonicalDate year month day
     where
     day :: Data.Date.Component.Day
-    day = get (Data.Symbol.SProxy :: _ "day")
+    day = get (Type.Proxy.Proxy :: _ "day")
 
     month :: Data.Date.Component.Month
-    month = Option.getWithDefault bottom (Data.Symbol.SProxy :: _ "month") options
+    month = Option.getWithDefault bottom (Type.Proxy.Proxy :: _ "month") options
 
     year :: Data.Date.Component.Year
-    year = get (Data.Symbol.SProxy :: _ "year")
+    year = get (Type.Proxy.Proxy :: _ "year")
 
   get ::
     forall label proxy record' value.
@@ -65,16 +66,16 @@ dateTime record = Data.DateTime.DateTime date time
   time = Data.Time.Time hour minute second millisecond
     where
     hour :: Data.Time.Component.Hour
-    hour = get (Data.Symbol.SProxy :: _ "hour")
+    hour = get (Type.Proxy.Proxy :: _ "hour")
 
     minute :: Data.Time.Component.Minute
-    minute = get (Data.Symbol.SProxy :: _ "minute")
+    minute = get (Type.Proxy.Proxy :: _ "minute")
 
     millisecond :: Data.Time.Component.Millisecond
-    millisecond = get (Data.Symbol.SProxy :: _ "millisecond")
+    millisecond = get (Type.Proxy.Proxy :: _ "millisecond")
 
     second :: Data.Time.Component.Second
-    second = get (Data.Symbol.SProxy :: _ "second")
+    second = get (Type.Proxy.Proxy :: _ "second")
 
 spec :: Test.Spec.Spec Unit
 spec =


### PR DESCRIPTION
## Context

`Data.Symbol.SProxy`, `Type.Data.RowList.RLProxy`, and similar mono-kinded proxies are deprecated in PureScript 0.14.x and removed in PureScript 0.15.x. Now that we're on a version of PureScript that supports poly-kinded types, we don't even have to think about `Data.Symbol.SProxy _`, `Type.Data.RowList.RLProxy _`, or whatever the next iteration of that stuff is. We can instead make our internal `Option.Proxy` poly-kinded, and not deal with the shuffling from `purescript-prelude`.

We update the tests to use `Type.Proxy.Proxy _`, since the tests are supposed to be validating the public API and making sure it works with the larger PureScript ecosystem. We also update the comments to mention this new world instead of referencing things that don't exist anymore.

## Testing

This does not change the kinds/types of anything that is exported. The changes to the test are not from required behavioral changes, but only to stay in line with the larger PureScript ecosystem. CI compiling/tests passing should give us enough confidence that we're doing the right thing.